### PR TITLE
Accept kebab-case for rule names in CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Options:
 
     only the rules specified will be used to validate the schema
 
-    example: --only FieldsHaveDescriptions,TypesHaveDescriptions
+    example: --only fields-have-descriptions,types-have-descriptions
 
   -e, --except <rules>
 
     all rules except the ones specified will be used to validate the schema
 
-    example: --except FieldsHaveDescriptions,TypesHaveDescriptions
+    example: --except fields-have-descriptions,types-have-descriptions
 
   -f, --format <format>
 
@@ -61,23 +61,23 @@ Options:
 
 ## Built-in rules
 
-### `DeprecationsHaveAReason`
+### `deprecations-have-a-reason`
 
 This rule will validate that all deprecations have a reason.
 
-### `EnumValuesSortedAlphabetically`
+### `enum-values-sorted-alphabetically`
 
 This rule will validate that all enum values are sorted alphabetically.
 
-### `FieldsHaveDescriptions`
+### `fields-have-descriptions`
 
 This rule will validate that all fields have a description.
 
-### `TypesAreCapitalized`
+### `types-are-capitalized`
 
 This rule will validate that interface types and object types have capitalized names.
 
-### `TypesHaveDescriptions`
+### `types-have-descriptions`
 
 This will will validate that interface types and object types have descriptions.
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,6 +11,6 @@ process.on('uncaughtException', (err) => {
   process.exit(2);
 });
 
-const exitCode = run(process.stdout, process.argv);
+const exitCode = run(process.stdout, process.stdin, process.argv);
 
 process.exit(exitCode);

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -5,15 +5,16 @@ import getGraphQLProjectConfig from 'graphql-config';
 import { readSync, readFileSync } from 'fs';
 
 export class Configuration {
-  constructor(options) {
+  constructor(options, stdinFd) {
     this.options = options;
+    this.stdinFd = stdinFd;
   }
 
   getSchema() {
     // TODO - Check for args.length > 1
 
     if (this.options.stdin) {
-      return getSchemaFromStdin();
+      return getSchemaFromFileDescriptor(this.stdinFd);
     } else if (this.options.args.length > 0) {
       return getSchemaFromFile(this.options.args[0]);
     } else {
@@ -51,12 +52,12 @@ export class Configuration {
   }
 };
 
-function getSchemaFromStdin() {
+function getSchemaFromFileDescriptor(fd) {
   var b = new Buffer(1024);
   var data = '';
 
   while (true) {
-    var n = readSync(process.stdin.fd, b, 0, b.length);
+    var n = readSync(fd, b, 0, b.length);
     if (!n) {
       break;
     }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -38,11 +38,11 @@ export class Configuration {
 
     if (this.options.only.length > 0) {
       rules = defaultRules.filter((rule) => {
-        return (this.options.only.indexOf(rule.name) >= 0);
+        return (this.options.only.map(toUpperCamelCase).indexOf(rule.name) >= 0);
       });
     } else if (this.options.except.length > 0) {
       rules = defaultRules.filter((rule) => {
-        return (this.options.except.indexOf(rule.name) == -1);
+        return (this.options.except.map(toUpperCamelCase).indexOf(rule.name) == -1);
       });
     } else {
       rules = defaultRules;
@@ -69,4 +69,8 @@ function getSchemaFromFileDescriptor(fd) {
 
 function getSchemaFromFile(path) {
   return readFileSync(path).toString('utf8');
+}
+
+function toUpperCamelCase(string) {
+  return string.split('-').map((part) => part[0].toUpperCase() + part.slice(1)).join('')
 }

--- a/src/runner.js
+++ b/src/runner.js
@@ -4,7 +4,7 @@ import { version } from '../package.json';
 import commander from 'commander';
 import { Configuration } from './configuration.js';
 
-export function run(stdout, argv) {
+export function run(stdout, stdin, argv) {
   commander
     .usage('[options] [schema.graphql]')
     .option('-o, --only <rules>', 'only the rules specified will be used to validate the schema. Example: FieldsHaveDescriptions,TypesHaveDescriptions')
@@ -20,7 +20,7 @@ export function run(stdout, argv) {
     only: (commander.only && commander.only.split(',')) || [],
     except: (commander.except && commander.except.split(',')) || [],
     args: commander.args,
-  });
+  }, stdin.fd);
 
   const schema = configuration.getSchema();
   const formatter = configuration.getFormatter();

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -1,0 +1,93 @@
+import assert from 'assert';
+import defaultRules from '../src/rules/index.js';
+import { Configuration } from '../src/configuration.js';
+import JSONFormatter from '../src/formatters/json_formatter.js';
+import TextFormatter from '../src/formatters/text_formatter.js';
+import { openSync, readFileSync } from 'fs';
+
+describe('Configuration', () => {
+  describe('getSchema', () => {
+    it('raises when more than one file is specified', () => {
+      // TODO
+    });
+
+    it('reads schema from file when provided', () => {
+      const fixturePath = `${__dirname}/fixtures/schema.graphql`;
+      const configuration = new Configuration({ args: [fixturePath] });
+      assert.equal(configuration.getSchema(), readFileSync(fixturePath).toString('utf8'));
+    });
+
+    it('reads schema from stdin when --stdin is set', () => {
+      const fixturePath = `${__dirname}/fixtures/schema.graphql`;
+      const fd = openSync(fixturePath, 'r');
+
+      const configuration = new Configuration({ args: [], stdin: true }, fd);
+      assert.equal(configuration.getSchema(), readFileSync(fixturePath).toString('utf8'));
+    });
+  });
+
+  describe('getFormatter', () => {
+    it('returns text formatter', () => {
+      const configuration = new Configuration({ format: 'text' });
+      assert.equal(configuration.getFormatter(), TextFormatter);
+    });
+
+    it('returns json formatter', () => {
+      const configuration = new Configuration({ format: 'json' });
+      assert.equal(configuration.getFormatter(), JSONFormatter);
+    });
+
+    it('raises on invalid formatter', () => {
+      // TODO
+    });
+  });
+
+  describe('getRules', () => {
+    it('raises when both --only and --except are specified', () => {
+      // TODO
+    });
+
+    it('returns default rules when --only and --except are not specified', () => {
+      const configuration = new Configuration({ only: [], except: [] });
+      assert.equal(configuration.getRules(), defaultRules);
+    });
+
+    it('omits rules that are not specified in --only', () => {
+      const configuration = new Configuration({ only: ['fields-have-descriptions', 'types-have-descriptions'], except: [] });
+
+      const rules = configuration.getRules();
+
+      assert.equal(rules.length, 2);
+      assert.equal(rules[0], defaultRules.find((rule) => { return rule.name == 'FieldsHaveDescriptions'; }));
+      assert.equal(rules[1], defaultRules.find((rule) => { return rule.name == 'TypesHaveDescriptions'; }));
+    });
+
+    it('omits rules that are specified in --except', () => {
+      const configuration = new Configuration({ only: [], except: ['fields-have-descriptions', 'types-have-descriptions'] });
+
+      const rules = configuration.getRules();
+
+      assert.equal(rules.length, defaultRules.length - 2);
+      assert.equal(0, rules.filter((rule) => { return rule.name == 'FieldsHaveDescriptions' || rule.name == 'TypesHaveDescriptions'; }).length);
+    });
+
+    it('omits rules that are not specified in --only (PascalCase)', () => {
+      const configuration = new Configuration({ only: ['FieldsHaveDescriptions', 'TypesHaveDescriptions'], except: [] });
+
+      const rules = configuration.getRules();
+
+      assert.equal(rules.length, 2);
+      assert.equal(rules[0], defaultRules.find((rule) => { return rule.name == 'FieldsHaveDescriptions'; }));
+      assert.equal(rules[1], defaultRules.find((rule) => { return rule.name == 'TypesHaveDescriptions'; }));
+    });
+
+    it('omits rules that are specified in --except (PascalCase)', () => {
+      const configuration = new Configuration({ only: [], except: ['FieldsHaveDescriptions', 'TypesHaveDescriptions'] });
+
+      const rules = configuration.getRules();
+
+      assert.equal(rules.length, defaultRules.length - 2);
+      assert.equal(0, rules.filter((rule) => { return rule.name == 'FieldsHaveDescriptions' || rule.name == 'TypesHaveDescriptions'; }).length);
+    });
+  });
+});

--- a/test/fixtures/schema.graphql
+++ b/test/fixtures/schema.graphql
@@ -1,0 +1,3 @@
+type QueryRoot {
+  a: String!
+}

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ require('babel-core').transform('code', {
 });
 
 // The tests, however, can and should be written with ECMAScript 2015.
+require('./configuration')
 require('./rules/fields_have_descriptions')
 require('./rules/types_have_descriptions')
 require('./rules/deprecations_have_a_reason')


### PR DESCRIPTION
Fixes #17 

Previously the rule names had to be specified in Pascal Case i.e. `--only FieldsHaveDescriptions`.

This PR adds support for `fields-have-descriptions` while keeping backwards compatibility with `FieldsHaveDescriptions` in the meantime.

FYI @goldcaddy77 