### PR TITLE
Deprecate `--only` and `--except`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,11 @@ Usage: graphql-schema-linter [options] [schema.graphql]
 
 Options:
 
-  -o, --only <rules>
+  -r, --rules <rules>
 
     only the rules specified will be used to validate the schema
 
-    example: --only fields-have-descriptions,types-have-descriptions
-
-  -e, --except <rules>
-
-    all rules except the ones specified will be used to validate the schema
-
-    example: --except fields-have-descriptions,types-have-descriptions
+    example: --rules fields-have-descriptions,types-have-descriptions
 
   -f, --format <format>
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,11 @@ process.on('uncaughtException', err => {
   process.exit(2);
 });
 
-const exitCode = run(process.stdout, process.stdin, process.argv);
+const exitCode = run(
+  process.stdout,
+  process.stdin,
+  process.stderr,
+  process.argv
+);
 
 process.exit(exitCode);

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -88,7 +88,9 @@ function loadOptionsFromConfig(configDirectory) {
   }).load(searchPath);
 
   if (cosmic) {
-    return cosmic.config;
+    return {
+      rules: cosmic.config.rules,
+    };
   } else {
     return {};
   }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -11,9 +11,8 @@ export class Configuration {
   /*
     options:
       - configDirectory: path to begin searching for config files
-      - except: [string array] blacklist rules
       - format: (required) `text` | `json`
-      - only: [string array] whitelist rules
+      - rules: [string array] whitelist rules
       - schemaFileName: [string] file to read schema from
       - stdin: [boolean] pass schema via stdin?
   */
@@ -21,19 +20,17 @@ export class Configuration {
     const defaultOptions = { format: 'text' };
     const configOptions = loadOptionsFromConfig(options.configDirectory);
 
+    // TODO Get configs from .graphqlconfig file
+
     this.options = Object.assign({}, defaultOptions, configOptions, options);
     this.stdinFd = stdinFd;
   }
 
   getSchema() {
-    // TODO - Check for args.length > 1
-
     if (this.options.stdin) {
       return getSchemaFromFileDescriptor(this.stdinFd);
     } else if (this.options.schemaFileName) {
       return getSchemaFromFile(this.options.schemaFileName);
-    } else {
-      // TODO: Get schema from .graphqlconfig file
     }
   }
 
@@ -43,23 +40,38 @@ export class Configuration {
         return JSONFormatter;
       case 'text':
         return TextFormatter;
+
       // TODO raise when invalid formatter
     }
   }
 
   getRules() {
-    // TODO Cannot have both except and only -- raise in this case
-    // TODO validate that all rules passed to only/except exist.
+    // TODO validate that all specified rules actually exist. This way we can
+    //      prevent people from making typos.
 
     var rules = defaultRules;
+    var specifiedRules;
 
+    if (this.options.rules && this.options.rules.length > 0) {
+      specifiedRules = this.options.rules.map(toUpperCamelCase);
+      rules = rules.filter(rule => {
+        return specifiedRules.indexOf(rule.name) >= 0;
+      });
+    }
+
+    // DEPRECATED - This code should be removed in v1.0.0.
     if (this.options.only && this.options.only.length > 0) {
-      rules = filterRules(this.options.only);
-    } else if (this.options.except && this.options.except.length > 0) {
+      specifiedRules = this.options.only.map(toUpperCamelCase);
       rules = defaultRules.filter(rule => {
-        return (
-          this.options.except.map(toUpperCamelCase).indexOf(rule.name) == -1
-        );
+        return specifiedRules.indexOf(rule.name) >= 0;
+      });
+    }
+
+    // DEPRECATED - This code should be removed in v1.0.0.
+    if (this.options.except && this.options.except.length > 0) {
+      specifiedRules = this.options.except.map(toUpperCamelCase);
+      rules = defaultRules.filter(rule => {
+        return specifiedRules.indexOf(rule.name) == -1;
       });
     }
 
@@ -68,28 +80,18 @@ export class Configuration {
 }
 
 function loadOptionsFromConfig(configDirectory) {
-  // If config path is not specified, look in root directory of project
-  // the first option to cosmiconfig.load can be absolute or relative
   const searchPath = configDirectory || './';
 
   const cosmic = cosmiconfig('graphql-schema-linter', {
     cache: false,
     sync: true,
   }).load(searchPath);
-  let options = {};
-  if (cosmic) {
-    // Map config.rules -> `only` param
-    if (cosmic.config.rules) {
-      options.only = cosmic.config.rules;
-    }
-  }
-  return options;
-}
 
-function filterRules(rules) {
-  return defaultRules.filter(rule => {
-    return rules.map(toUpperCamelCase).indexOf(rule.name) >= 0;
-  });
+  if (cosmic) {
+    return cosmic.config;
+  } else {
+    return {};
+  }
 }
 
 function getSchemaFromFileDescriptor(fd) {

--- a/src/runner.js
+++ b/src/runner.js
@@ -3,21 +3,15 @@ import { rules } from './index.js';
 import { version } from '../package.json';
 import commander from 'commander';
 import { Configuration } from './configuration.js';
+import figures from 'figures';
+import chalk from 'chalk';
 
-export function run(stdout, stdin, argv) {
+export function run(stdout, stdin, stderr, argv) {
   commander
     .usage('[options] [schema.graphql]')
     .option(
-      '-o, --only <rules>',
-      'only the rules specified will be used to validate the schema. Example: FieldsHaveDescriptions,TypesHaveDescriptions'
-    )
-    .option(
-      '-c, --config-directory <path>',
-      'path to begin searching for config files.'
-    )
-    .option(
-      '-e, --except <rules>',
-      'all rules except the ones specified will be used to validate the schema. Example: FieldsHaveDescriptions,TypesHaveDescriptions'
+      '-r, --rules <rules>',
+      'only the rules specified will be used to validate the schema. Example: fields-have-descriptions,types-have-descriptions'
     )
     .option(
       '-f, --format <format>',
@@ -27,8 +21,33 @@ export function run(stdout, stdin, argv) {
       '-s, --stdin',
       'schema definition will be read from STDIN instead of specified file.'
     )
+    .option(
+      '-c, --config-directory <path>',
+      'path to begin searching for config files.'
+    )
+    // DEPRECATED - This code should be removed in v1.0.0.
+    .option(
+      '-o, --only <rules>',
+      'This option is DEPRECATED. Use `--rules` instead.'
+    )
+    // DEPRECATED - This code should be removed in v1.0.0.
+    .option(
+      '-e, --except <rules>',
+      'This option is DEPRECATED. Use `--rules` instead.'
+    )
     .version(version, '--version')
     .parse(argv);
+
+  if (commander.only || commander.except) {
+    stderr.write(
+      `${chalk.yellow(figures.warning)} The ${chalk.bold(
+        '--only'
+      )} and ${chalk.bold('--except')} command line options ` +
+        `have been deprecated. They will be removed in ${chalk.bold(
+          'v1.0.0'
+        )}.\n\n`
+    );
+  }
 
   const configuration = new Configuration(
     getOptionsFromCommander(commander),
@@ -63,6 +82,10 @@ function getOptionsFromCommander(commander) {
 
   if (commander.only) {
     options.only = commander.only.split(',');
+  }
+
+  if (commander.rules) {
+    options.rules = commander.rules.split(',');
   }
 
   if (commander.args && commander.args.length) {


### PR DESCRIPTION
Fixes #25

We are favouring whitelists as it will make it easier for us to introduce new rules without it being a breaking change for existing users.

There is a bit of code duplication in this PR but it is okay since we will be :fire: the code in the coming days/weeks as we release v1.0.0.

cc @goldcaddy77 