### PR TITLE
Add support for schemas that are split amongst many files

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,16 @@ Sample output:
       "message": "The object type `QueryRoot` is missing a description.",
       "location": {
         "line": 5,
-        "column": 1
+        "column": 1,
+        "file": "schema.graphql"
       }
     },
     {
       "message": "The field `QueryRoot.a` is missing a description.",
       "location": {
         "line": 6,
-        "column": 3
+        "column": 3,
+        "file": "schema.graphql"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install -g graphql-schema-linter
 ## Usage
 
 ```
-Usage: graphql-schema-linter [options] [schema.graphql]
+Usage: graphql-schema-linter [options] [schema.graphql ...]
 
 
 Options:

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "commander": "^2.11.0",
     "cosmiconfig": "davidtheclark/cosmiconfig#3.0",
     "figures": "^2.0.0",
+    "glob": "^7.1.2",
     "graphql": "^0.10.1",
     "graphql-config": "^1.0.0"
   },

--- a/src/formatters/json_formatter.js
+++ b/src/formatters/json_formatter.js
@@ -1,10 +1,25 @@
-export default function JSONFormatter(errors) {
+export default function JSONFormatter(errorsGroupedByFile) {
+  const files = Object.keys(errorsGroupedByFile);
+
+  var errors = [];
+
+  files.forEach(file => {
+    Array.prototype.push.apply(
+      errors,
+      errorsGroupedByFile[file].map(error => {
+        return {
+          message: error.message,
+          location: {
+            line: error.locations[0].line,
+            column: error.locations[0].column,
+            file: file,
+          },
+        };
+      })
+    );
+  });
+
   return JSON.stringify({
-    errors: errors.map(error => {
-      return {
-        message: error.message,
-        location: error.locations[0],
-      };
-    }),
+    errors,
   });
 }

--- a/src/formatters/text_formatter.js
+++ b/src/formatters/text_formatter.js
@@ -2,7 +2,21 @@ import columnify from 'columnify';
 import figures from 'figures';
 import chalk from 'chalk';
 
-export default function TextFormatter(errors) {
+export default function TextFormatter(errorsGroupedByFile) {
+  const files = Object.keys(errorsGroupedByFile);
+
+  const errorsText = files
+    .map(file => {
+      return generateErrorsForFile(file, errorsGroupedByFile[file]);
+    })
+    .join('\n\n');
+
+  const summary = generateSummary(errorsGroupedByFile);
+
+  return errorsText + '\n\n' + summary + '\n';
+}
+
+function generateErrorsForFile(file, errors) {
   const formattedErrors = errors.map(error => {
     const location = error.locations[0];
 
@@ -13,19 +27,29 @@ export default function TextFormatter(errors) {
     };
   });
 
-  if (errors.length == 0) {
-    return chalk.green(`${figures.tick} 0 errors detected\n`);
-  }
-
-  const summary = chalk.red(
-    `${figures.cross} ${errors.length} error` +
-      (errors.length > 1 ? 's' : '') +
-      ' detected'
-  );
-
   const errorsText = columnify(formattedErrors, {
     showHeaders: false,
   });
 
-  return errorsText + '\n\n' + summary + '\n';
+  return chalk.underline(file) + '\n' + errorsText;
+}
+
+function generateSummary(errorsGroupedByFile) {
+  const files = Object.keys(errorsGroupedByFile);
+
+  const errorsCount = files.reduce((sum, file) => {
+    return sum + errorsGroupedByFile[file].length;
+  }, 0);
+
+  if (errorsCount == 0) {
+    return chalk.green(`${figures.tick} 0 errors detected\n`);
+  }
+
+  const summary = chalk.red(
+    `${figures.cross} ${errorsCount} error` +
+      (errorsCount > 1 ? 's' : '') +
+      ' detected'
+  );
+
+  return summary;
 }

--- a/src/runner.js
+++ b/src/runner.js
@@ -57,8 +57,9 @@ export function run(stdout, stdin, stderr, argv) {
   const schema = configuration.getSchema();
   const formatter = configuration.getFormatter();
   const rules = configuration.getRules();
+  const schemaFileOffsets = configuration.getSchemaFileOffsets();
 
-  const errors = validateSchemaDefinition(schema, rules);
+  const errors = validateSchemaDefinition(schema, schemaFileOffsets, rules);
 
   stdout.write(formatter(errors));
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -74,6 +74,10 @@ function groupErrorsBySchemaFilePath(errors, schemaSourceMap) {
       error.locations[0].line
     );
 
+    const offsetForPath = schemaSourceMap.getOffsetForPath(path);
+    error.locations[0].line =
+      error.locations[0].line - offsetForPath.startLine + 1;
+
     groupedErrors[path] = groupedErrors[path] || [];
     groupedErrors[path].push(error);
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -1,14 +1,14 @@
 import { validateSchemaDefinition } from './validator.js';
 import { rules } from './index.js';
 import { version } from '../package.json';
-import commander from 'commander';
+import { Command } from 'commander';
 import { Configuration } from './configuration.js';
 import figures from 'figures';
 import chalk from 'chalk';
 
 export function run(stdout, stdin, stderr, argv) {
-  commander
-    .usage('[options] [schema.graphql]')
+  const commander = new Command()
+    .usage('[options] [schema.graphql ...]')
     .option(
       '-r, --rules <rules>',
       'only the rules specified will be used to validate the schema. Example: fields-have-descriptions,types-have-descriptions'
@@ -105,7 +105,7 @@ function getOptionsFromCommander(commander) {
   }
 
   if (commander.args && commander.args.length) {
-    options.schemaFileName = commander.args[0];
+    options.schemaPaths = commander.args;
   }
 
   return options;

--- a/src/source_map.js
+++ b/src/source_map.js
@@ -9,7 +9,7 @@ export class SourceMap {
 
     const paths = Object.keys(this.sourceFiles);
 
-    return paths.map(path => {
+    return paths.reduce((offsets, path) => {
       const currentSegment = this.sourceFiles[path];
       const amountLines = currentSegment.match(/\r?\n/g).length;
 
@@ -18,12 +18,14 @@ export class SourceMap {
 
       currentOffset = currentOffset + amountLines + 1;
 
-      return {
+      offsets[path] = {
         startLine,
         endLine,
         filename: path,
       };
-    });
+
+      return offsets;
+    }, {});
   }
 
   getCombinedSource() {
@@ -31,13 +33,19 @@ export class SourceMap {
   }
 
   getOriginalPathForLine(lineNumber) {
-    for (var i = 0; i < this.offsets.length; i++) {
+    const offsets = Object.values(this.offsets);
+
+    for (var i = 0; i < offsets.length; i++) {
       if (
-        this.offsets[i].startLine <= lineNumber &&
-        lineNumber <= this.offsets[i].endLine
+        offsets[i].startLine <= lineNumber &&
+        lineNumber <= offsets[i].endLine
       ) {
-        return this.offsets[i].filename;
+        return offsets[i].filename;
       }
     }
+  }
+
+  getOffsetForPath(path) {
+    return this.offsets[path];
   }
 }

--- a/src/source_map.js
+++ b/src/source_map.js
@@ -1,0 +1,43 @@
+export class SourceMap {
+  constructor(sourceFiles) {
+    this.sourceFiles = sourceFiles;
+    this.offsets = this._computeOffsets();
+  }
+
+  _computeOffsets() {
+    var currentOffset = 1;
+
+    const paths = Object.keys(this.sourceFiles);
+
+    return paths.map(path => {
+      const currentSegment = this.sourceFiles[path];
+      const amountLines = currentSegment.match(/\r?\n/g).length;
+
+      const startLine = currentOffset;
+      const endLine = currentOffset + amountLines;
+
+      currentOffset = currentOffset + amountLines + 1;
+
+      return {
+        startLine,
+        endLine,
+        filename: path,
+      };
+    });
+  }
+
+  getCombinedSource() {
+    return Object.values(this.sourceFiles).join('\n');
+  }
+
+  getOriginalPathForLine(lineNumber) {
+    for (var i = 0; i < this.offsets.length; i++) {
+      if (
+        this.offsets[i].startLine <= lineNumber &&
+        lineNumber <= this.offsets[i].endLine
+      ) {
+        return this.offsets[i].filename;
+      }
+    }
+  }
+}

--- a/src/validator.js
+++ b/src/validator.js
@@ -3,52 +3,17 @@ import { visit, visitInParallel } from 'graphql/language/visitor';
 import { validate } from 'graphql/validation';
 import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 
-export function validateSchemaDefinition(
-  schemaDefinition,
-  schemaFileOffsets,
-  rules
-) {
+export function validateSchemaDefinition(schemaDefinition, rules) {
   const ast = parse(schemaDefinition);
   const schema = buildASTSchema(ast);
   const errors = validate(schema, ast, rules);
   const sortedErrors = sortErrors(errors);
-  const groupedErrors = groupErrorsByFile(sortedErrors, schemaFileOffsets);
 
-  return groupedErrors;
+  return sortedErrors;
 }
 
 function sortErrors(errors) {
   return errors.sort((a, b) => {
     return a.locations[0].line - b.locations[0].line;
   });
-}
-
-function groupErrorsByFile(errors, schemaFileOffsets) {
-  var groups = {};
-
-  var currentFileOffset = 0;
-
-  for (var i = 0; i < errors.length; i++) {
-    var error = errors[i];
-    var errorLine = error.locations[0].line;
-
-    for (var j = currentFileOffset; j < schemaFileOffsets.length; j++) {
-      if (
-        schemaFileOffsets[j].startLine <= errorLine &&
-        errorLine <= schemaFileOffsets[j].endLine
-      ) {
-        var filename = schemaFileOffsets[j].filename;
-        groups[filename] = groups[filename] || [];
-
-        error.locations[0].line =
-          error.locations[0].line - schemaFileOffsets[j].startLine + 1;
-        groups[filename].push(error);
-
-        currentFileOffset = j;
-        break;
-      }
-    }
-  }
-
-  return groups;
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -3,10 +3,52 @@ import { visit, visitInParallel } from 'graphql/language/visitor';
 import { validate } from 'graphql/validation';
 import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 
-export function validateSchemaDefinition(schemaDefinition, rules) {
+export function validateSchemaDefinition(
+  schemaDefinition,
+  schemaFileOffsets,
+  rules
+) {
   const ast = parse(schemaDefinition);
   const schema = buildASTSchema(ast);
   const errors = validate(schema, ast, rules);
+  const sortedErrors = sortErrors(errors);
+  const groupedErrors = groupErrorsByFile(sortedErrors, schemaFileOffsets);
 
-  return errors;
+  return groupedErrors;
+}
+
+function sortErrors(errors) {
+  return errors.sort((a, b) => {
+    return a.locations[0].line - b.locations[0].line;
+  });
+}
+
+function groupErrorsByFile(errors, schemaFileOffsets) {
+  var groups = {};
+
+  var currentFileOffset = 0;
+
+  for (var i = 0; i < errors.length; i++) {
+    var error = errors[i];
+    var errorLine = error.locations[0].line;
+
+    for (var j = currentFileOffset; j < schemaFileOffsets.length; j++) {
+      if (
+        schemaFileOffsets[j].startLine <= errorLine &&
+        errorLine <= schemaFileOffsets[j].endLine
+      ) {
+        var filename = schemaFileOffsets[j].filename;
+        groups[filename] = groups[filename] || [];
+
+        error.locations[0].line =
+          error.locations[0].line - schemaFileOffsets[j].startLine + 1;
+        groups[filename].push(error);
+
+        currentFileOffset = j;
+        break;
+      }
+    }
+  }
+
+  return groups;
 }

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -9,7 +9,7 @@ describe('Configuration', () => {
   describe('getSchema', () => {
     it('concatenates multiple files when given a glob', () => {
       const schemaPath = `${__dirname}/fixtures/schema/**/*.graphql`;
-      const configuration = new Configuration({ schemaFileName: schemaPath });
+      const configuration = new Configuration({ schemaPaths: [schemaPath] });
 
       const expectedSchema = `type Query {
   something: String!
@@ -34,7 +34,7 @@ extend type Query {
 
     it('reads schema from file when provided', () => {
       const fixturePath = `${__dirname}/fixtures/schema.graphql`;
-      const configuration = new Configuration({ schemaFileName: fixturePath });
+      const configuration = new Configuration({ schemaPaths: [fixturePath] });
       assert.equal(
         configuration.getSchema(),
         readFileSync(fixturePath).toString('utf8')

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -161,39 +161,4 @@ extend type Query {
       );
     });
   });
-
-  describe('getSchemaFileOffsets', () => {
-    it('returns offsets for a schema built from a single GraphQL file', () => {
-      const schemaPath = `${__dirname}/fixtures`;
-      const configuration = new Configuration({
-        schemaFileName: `${schemaPath}/schema.graphql`,
-      });
-      assert.deepEqual(configuration.getSchemaFileOffsets(), [
-        { startLine: 1, endLine: 4, filename: `${schemaPath}/schema.graphql` },
-      ]);
-    });
-
-    it('returns offsets for a schema built from multiple GraphQL files', () => {
-      const schemaPath = `${__dirname}/fixtures/schema`;
-      const configuration = new Configuration({
-        schemaFileName: `${schemaPath}/*.graphql`,
-      });
-
-      assert.deepEqual(configuration.getSchemaFileOffsets(), [
-        { startLine: 1, endLine: 8, filename: `${schemaPath}/schema.graphql` },
-        { startLine: 9, endLine: 17, filename: `${schemaPath}/user.graphql` },
-      ]);
-    });
-
-    it('returns offsets for a schema built from stdin', () => {
-      const fixturePath = `${__dirname}/fixtures/schema.graphql`;
-      const fd = openSync(fixturePath, 'r');
-
-      const configuration = new Configuration({ args: [], stdin: true }, fd);
-
-      assert.deepEqual(configuration.getSchemaFileOffsets(), [
-        { startLine: 1, endLine: 4, filename: 'stdin' },
-      ]);
-    });
-  });
 });

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -11,7 +11,12 @@ describe('Configuration', () => {
       const schemaPath = `${__dirname}/fixtures/schema/**/*.graphql`;
       const configuration = new Configuration({ schemaPaths: [schemaPath] });
 
-      const expectedSchema = `type Query {
+      const expectedSchema = `type Comment {
+  body: String!
+  author: User!
+}
+
+type Query {
   something: String!
 }
 

--- a/test/fixtures/schema/comment.graphql
+++ b/test/fixtures/schema/comment.graphql
@@ -1,0 +1,4 @@
+type Comment {
+  body: String!
+  author: User!
+}

--- a/test/fixtures/schema/schema.graphql
+++ b/test/fixtures/schema/schema.graphql
@@ -1,0 +1,7 @@
+type Query {
+  something: String!
+}
+
+schema {
+  query: Query
+}

--- a/test/fixtures/schema/user.graphql
+++ b/test/fixtures/schema/user.graphql
@@ -1,0 +1,8 @@
+type User {
+  username: String!
+  email: String!
+}
+
+extend type Query {
+  viewer: User!
+}

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ require('babel-core').transform('code', {
 // The tests, however, can and should be written with ECMAScript 2015.
 require('./configuration');
 require('./runner');
+require('./validator');
 require('./rules/fields_have_descriptions');
 require('./rules/types_have_descriptions');
 require('./rules/deprecations_have_a_reason');

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ require('babel-core').transform('code', {
 // The tests, however, can and should be written with ECMAScript 2015.
 require('./configuration');
 require('./runner');
+require('./source_map');
 require('./validator');
 require('./rules/fields_have_descriptions');
 require('./rules/types_have_descriptions');

--- a/test/runner.js
+++ b/test/runner.js
@@ -59,5 +59,40 @@ describe('Runner', () => {
       var errors = JSON.parse(stdout);
       assert.equal(1, errors['errors'].length);
     });
+
+    it('validates a schema composed of multiple files (glob) and outputs in json', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'json',
+        '--rules',
+        'fields-have-descriptions',
+        `${__dirname}/fixtures/schema/*.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      var errors = JSON.parse(stdout);
+      assert.equal(4, errors['errors'].length);
+    });
+
+    it('validates a schema composed of multiple files (args) and outputs in json', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'json',
+        '--rules',
+        'fields-have-descriptions',
+        `${__dirname}/fixtures/schema/schema.graphql`,
+        `${__dirname}/fixtures/schema/user.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      var errors = JSON.parse(stdout);
+      assert.equal(4, errors['errors'].length);
+    });
   });
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -39,8 +39,9 @@ describe('Runner', () => {
 
       run(mockStdout, mockStdin, mockStderr, argv);
 
-      var errors = JSON.parse(stdout);
-      assert.equal(1, errors['errors'].length);
+      var errors = JSON.parse(stdout)['errors'];
+      assert(errors);
+      assert.equal(1, errors.length);
     });
 
     it('validates schema passed in via stdin and outputs in json', () => {
@@ -56,8 +57,9 @@ describe('Runner', () => {
 
       run(mockStdout, mockStdin, mockStderr, argv);
 
-      var errors = JSON.parse(stdout);
-      assert.equal(1, errors['errors'].length);
+      var errors = JSON.parse(stdout)['errors'];
+      assert(errors);
+      assert.equal(1, errors.length);
     });
 
     it('validates a schema composed of multiple files (glob) and outputs in json', () => {
@@ -73,8 +75,9 @@ describe('Runner', () => {
 
       run(mockStdout, mockStdin, mockStderr, argv);
 
-      var errors = JSON.parse(stdout);
-      assert.equal(4, errors['errors'].length);
+      var errors = JSON.parse(stdout)['errors'];
+      assert(errors);
+      assert.equal(6, errors.length);
     });
 
     it('validates a schema composed of multiple files (args) and outputs in json', () => {
@@ -91,8 +94,90 @@ describe('Runner', () => {
 
       run(mockStdout, mockStdin, mockStderr, argv);
 
-      var errors = JSON.parse(stdout);
-      assert.equal(4, errors['errors'].length);
+      var errors = JSON.parse(stdout)['errors'];
+      assert(errors);
+      assert.equal(4, errors.length);
+    });
+
+    it('preserves original line numbers when schema is composed of multiple files', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'json',
+        '--rules',
+        'fields-have-descriptions',
+        `${__dirname}/fixtures/schema/schema.graphql`,
+        `${__dirname}/fixtures/schema/user.graphql`,
+        `${__dirname}/fixtures/schema/comment.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      var errors = JSON.parse(stdout)['errors'];
+      assert(errors);
+
+      assert.equal(6, errors.length);
+
+      assert.equal(
+        'The field `Query.something` is missing a description.',
+        errors[0].message
+      );
+      assert.equal(2, errors[0].location.line);
+      assert.equal(
+        `${__dirname}/fixtures/schema/schema.graphql`,
+        errors[0].location.file
+      );
+
+      assert.equal(
+        'The field `User.username` is missing a description.',
+        errors[1].message
+      );
+      assert.equal(2, errors[1].location.line);
+      assert.equal(
+        `${__dirname}/fixtures/schema/user.graphql`,
+        errors[1].location.file
+      );
+
+      assert.equal(
+        'The field `User.email` is missing a description.',
+        errors[2].message
+      );
+      assert.equal(3, errors[2].location.line);
+      assert.equal(
+        `${__dirname}/fixtures/schema/user.graphql`,
+        errors[2].location.file
+      );
+
+      assert.equal(
+        'The field `Query.viewer` is missing a description.',
+        errors[3].message
+      );
+      assert.equal(7, errors[3].location.line);
+      assert.equal(
+        `${__dirname}/fixtures/schema/user.graphql`,
+        errors[3].location.file
+      );
+
+      assert.equal(
+        'The field `Comment.body` is missing a description.',
+        errors[4].message
+      );
+      assert.equal(2, errors[4].location.line);
+      assert.equal(
+        `${__dirname}/fixtures/schema/comment.graphql`,
+        errors[4].location.file
+      );
+
+      assert.equal(
+        'The field `Comment.author` is missing a description.',
+        errors[5].message
+      );
+      assert.equal(3, errors[5].location.line);
+      assert.equal(
+        `${__dirname}/fixtures/schema/comment.graphql`,
+        errors[5].location.file
+      );
     });
   });
 });

--- a/test/source_map.js
+++ b/test/source_map.js
@@ -1,0 +1,46 @@
+import assert from 'assert';
+import { SourceMap } from '../src/source_map';
+
+const sourceFiles = {
+  'query.graphql': `type Query {
+  a: String!
+}`,
+
+  'user.graphql': `type User {
+  username: String!
+  email: String!
+}`,
+};
+
+describe('SourceMap', () => {
+  describe('getCombinedSource', () => {
+    it('returns combined source files', () => {
+      const sourceMap = new SourceMap(sourceFiles);
+
+      assert.equal(
+        sourceMap.getCombinedSource(),
+        `type Query {
+  a: String!
+}
+type User {
+  username: String!
+  email: String!
+}`
+      );
+    });
+  });
+
+  describe('getOriginalPathForLine', () => {
+    it('returns the path of the file that contains the source on the specified line number of the combined file', () => {
+      const sourceMap = new SourceMap(sourceFiles);
+
+      assert.equal('query.graphql', sourceMap.getOriginalPathForLine(1));
+      assert.equal('query.graphql', sourceMap.getOriginalPathForLine(2));
+      assert.equal('query.graphql', sourceMap.getOriginalPathForLine(3));
+      assert.equal('user.graphql', sourceMap.getOriginalPathForLine(4));
+      assert.equal('user.graphql', sourceMap.getOriginalPathForLine(5));
+      assert.equal('user.graphql', sourceMap.getOriginalPathForLine(6));
+      assert.equal('user.graphql', sourceMap.getOriginalPathForLine(7));
+    });
+  });
+});

--- a/test/validator.js
+++ b/test/validator.js
@@ -1,0 +1,49 @@
+import assert from 'assert';
+import { validateSchemaDefinition } from '../src/validator';
+import { Configuration } from '../src/configuration';
+import { FieldsHaveDescriptions } from '../src/rules/fields_have_descriptions';
+
+describe('validateSchemaDefinition', () => {
+  it('returns errors for a schema grouped by files', () => {
+    const schemaPath = `${__dirname}/fixtures/schema/**/*.graphql`;
+    const configuration = new Configuration({ schemaFileName: schemaPath });
+
+    const schemaDefinition = configuration.getSchema();
+    const schemaFileOffsets = configuration.getSchemaFileOffsets();
+    const rules = [FieldsHaveDescriptions];
+
+    const errors = validateSchemaDefinition(
+      schemaDefinition,
+      schemaFileOffsets,
+      rules
+    );
+
+    assert.deepEqual(Object.keys(errors), [
+      `${__dirname}/fixtures/schema/schema.graphql`,
+      `${__dirname}/fixtures/schema/user.graphql`,
+    ]);
+
+    assert.equal(
+      1,
+      errors[`${__dirname}/fixtures/schema/schema.graphql`].length
+    );
+    assert.equal(
+      2,
+      errors[`${__dirname}/fixtures/schema/schema.graphql`][0].locations[0].line
+    );
+
+    assert.equal(3, errors[`${__dirname}/fixtures/schema/user.graphql`].length);
+    assert.equal(
+      2,
+      errors[`${__dirname}/fixtures/schema/user.graphql`][0].locations[0].line
+    );
+    assert.equal(
+      3,
+      errors[`${__dirname}/fixtures/schema/user.graphql`][1].locations[0].line
+    );
+    assert.equal(
+      7,
+      errors[`${__dirname}/fixtures/schema/user.graphql`][2].locations[0].line
+    );
+  });
+});

--- a/test/validator.js
+++ b/test/validator.js
@@ -7,7 +7,7 @@ import { GraphQLError } from 'graphql/error';
 describe('validateSchemaDefinition', () => {
   it('returns errors sorted by line number', () => {
     const schemaPath = `${__dirname}/fixtures/schema/**/*.graphql`;
-    const configuration = new Configuration({ schemaFileName: schemaPath });
+    const configuration = new Configuration({ schemaPaths: [schemaPath] });
 
     const schemaDefinition = configuration.getSchema();
     const rules = [FieldsHaveDescriptions, DummyValidator];

--- a/test/validator.js
+++ b/test/validator.js
@@ -13,13 +13,13 @@ describe('validateSchemaDefinition', () => {
     const rules = [FieldsHaveDescriptions, DummyValidator];
 
     const errors = validateSchemaDefinition(schemaDefinition, rules);
+    const errorLineNumbers = errors.map(error => {
+      return error.locations[0].line;
+    });
 
-    assert.equal(5, errors.length);
-    assert.equal(1, errors[0].locations[0].line);
-    assert.equal(2, errors[1].locations[0].line);
-    assert.equal(10, errors[2].locations[0].line);
-    assert.equal(11, errors[3].locations[0].line);
-    assert.equal(15, errors[4].locations[0].line);
+    assert.equal(7, errors.length);
+
+    assert.deepEqual(errorLineNumbers.sort(), errorLineNumbers);
   });
 });
 


### PR DESCRIPTION
Fixes #37

This PR adds support for schemas that are split amongst multiple `.graphql` files.

For example:

```graphql
# schema/query.graphql

type Query {
  something: String!
}

# schema/user.graphql

type User {
  username: String!
  email: String!
}

extend type Query {
  viewer: User!
}
```

Users will be able to pass a glob and the final schema will be built by concatenating all matched files.

**Example:**

<img width="771" alt="screen shot 2017-08-23 at 9 57 02 pm" src="https://user-images.githubusercontent.com/385270/29645852-0c7dda36-884e-11e7-90e1-c44b7df7b474.png">

**TODO:**

- [ ] Document in `README.md`.
- [x] Handle case where shell expands the glob which leads to `graphql-schema-linter schema/*.graphql` getting converted to `graphql-schema-linter schema/query.graphql schema/user.graphql`.
- [x] Add some high level tests in `test/runner.js`.

@goldcaddy77 I would love your feedback on this feature/code whenever you have time.