### PR TITLE
Do not require descriptions on type extension definitions

### DIFF
--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -3,6 +3,10 @@ import { GraphQLError } from 'graphql/error';
 
 export function TypesHaveDescriptions(context) {
   return {
+    TypeExtensionDefinition(node) {
+      return false;
+    },
+
     InterfaceTypeDefinition(node) {
       if (getDescription(node)) {
         return;

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -57,4 +57,31 @@ describe('TypesHaveDescriptions rule', () => {
     );
     assert.deepEqual(errors[0].locations, [{ line: 7, column: 7 }]);
   });
+
+  it('ignores type extensions', () => {
+    const ast = parse(`
+      # The query root
+      type Query {
+        a: String
+      }
+
+      extend type Query {
+        b: String
+      }
+
+      # Interface
+      interface Vehicle {
+        make: String!
+      }
+
+      extend type Vehicle {
+        something: String!
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [TypesHaveDescriptions]);
+
+    assert.equal(errors.length, 0);
+  });
 });


### PR DESCRIPTION
```graphql
extend type Query {
  viewer: User!
}
```

The above snippet currently causes a `Missing description for Query` error.

The description for `Query` should be required for the `TypeDefinition`, but not for extensions.