### PR TITLE
fix(source-maps): add support for node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "node"
+  - "lts/*"

--- a/src/source_map.js
+++ b/src/source_map.js
@@ -29,11 +29,11 @@ export class SourceMap {
   }
 
   getCombinedSource() {
-    return Object.values(this.sourceFiles).join('\n');
+    return getObjectValues(this.sourceFiles).join('\n');
   }
 
   getOriginalPathForLine(lineNumber) {
-    const offsets = Object.values(this.offsets);
+    const offsets = getObjectValues(this.offsets);
 
     for (var i = 0; i < offsets.length; i++) {
       if (
@@ -48,4 +48,10 @@ export class SourceMap {
   getOffsetForPath(path) {
     return this.offsets[path];
   }
+}
+
+function getObjectValues(arr) {
+  return Object.keys(arr).map(function(key) {
+    return arr[key];
+  });
 }


### PR DESCRIPTION
Fixes #44 

`Object.values` doesn't seem to be supported in the [LTS version of Node](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values).  We should use a workaround [like this](https://stackoverflow.com/a/38748490) so that we support Node 6.