### PR TITLE
Cosmiconfig: refer by version instead of hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "chalk": "^2.0.1",
     "columnify": "^1.5.4",
     "commander": "^2.11.0",
-    "cosmiconfig":
-      "davidtheclark/cosmiconfig#6eb3cc85d3a435e6b9e252b341e601960312f410",
+    "cosmiconfig": "^3.1.0",
     "figures": "^2.0.0",
     "glob": "^7.1.2",
     "graphql": "^0.10.1",


### PR DESCRIPTION
The syntax currently used for the cosmiconfig line requires `git` to be installed. Docker images like node-alpine don't include git by default, so installing graphql-schema-linter fails on these systems.

The cosmiconfig repo now has proper tags for the 3.0 branch, so commit b0a2406 can be reverted.