### PR TITLE
Update README to fix lint-staged in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then add a `precommit` script and a `lint-staged` key to your `package.json` lik
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.graphql": ["graphql-schema-linter **/*.graphql"]
+    "*.graphql": ["graphql-schema-linter"]
   }
 }
 ```
@@ -85,8 +85,8 @@ multiple entries in the `lint-staged` object above - one for client and one for 
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "client/*.graphql": ["graphql-schema-linter client/**/*.graphql"],
-    "server/*.graphql": ["graphql-schema-linter server/**/*.graphql"],
+    "client/*.graphql": ["graphql-schema-linter"],
+    "server/*.graphql": ["graphql-schema-linter"],
   }
 }
 ```


### PR DESCRIPTION
In the lint-staged package.json instructions if you add the name of the graphql file(s) in the name and in the command the linter runs twice on the files resulting in duplicate type definition errors.
Fixing example configuration to only pass file name as label in lint-staged rather than in label and in command.