### PR TITLE
Union types require a description

### DIFF
--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -22,6 +22,21 @@ export function TypesHaveDescriptions(context) {
       );
     },
 
+    UnionTypeDefinition(node) {
+      if (getDescription(node)) {
+        return;
+      }
+
+      const unionTypeName = node.name.value;
+
+      context.reportError(
+        new GraphQLError(
+          `The union type \`${unionTypeName}\` is missing a description.`,
+          [node]
+        )
+      );
+    },
+
     ObjectTypeDefinition(node) {
       if (getDescription(node)) {
         return;

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -58,6 +58,42 @@ describe('TypesHaveDescriptions rule', () => {
     assert.deepEqual(errors[0].locations, [{ line: 7, column: 7 }]);
   });
 
+  it('catches union types that have no description', () => {
+    const ast = parse(`
+      # The query root
+      type QueryRoot {
+        a: String
+      }
+
+      # A
+      type A {
+        a: String
+      }
+
+      # B
+      type B {
+        b: String
+      }
+
+      union AB = A | B
+
+      schema {
+        query: QueryRoot
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [TypesHaveDescriptions]);
+
+    assert.equal(errors.length, 1);
+
+    assert.equal(
+      errors[0].message,
+      'The union type `AB` is missing a description.'
+    );
+    assert.deepEqual(errors[0].locations, [{ line: 17, column: 7 }]);
+  });
+
   it('ignores type extensions', () => {
     const ast = parse(`
       # The query root


### PR DESCRIPTION
Fixes #54 

`union` types without a `description` weren't getting caught by `types-have-descriptions` rule.

cc @mscharley