### PR TITLE
Input types require a description

### DIFF
--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -22,6 +22,21 @@ export function TypesHaveDescriptions(context) {
       );
     },
 
+    InputObjectTypeDefinition(node) {
+      if (getDescription(node)) {
+        return;
+      }
+
+      const interfaceTypeName = node.name.value;
+
+      context.reportError(
+        new GraphQLError(
+          `The input type \`${interfaceTypeName}\` is missing a description.`,
+          [node]
+        )
+      );
+    },
+
     UnionTypeDefinition(node) {
       if (getDescription(node)) {
         return;

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -30,6 +30,34 @@ describe('TypesHaveDescriptions rule', () => {
     assert.deepEqual(errors[0].locations, [{ line: 2, column: 7 }]);
   });
 
+  it('catches input types that have no description', () => {
+    const ast = parse(`
+      # Query
+      type QueryRoot {
+        a: String
+      }
+
+      input AddStar {
+        id: ID!
+      }
+
+      schema {
+        query: QueryRoot
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [TypesHaveDescriptions]);
+
+    assert.equal(errors.length, 1);
+
+    assert.equal(
+      errors[0].message,
+      'The input type `AddStar` is missing a description.'
+    );
+    assert.deepEqual(errors[0].locations, [{ line: 7, column: 7 }]);
+  });
+
   it('catches interface types that have no description', () => {
     const ast = parse(`
       # The query root


### PR DESCRIPTION
Fixes #55

`input` types without a `description` weren't getting caught by `types-have-descriptions` rule.

cc @mscharley