### PR TITLE
Support .graphql files that have no line breaks

### DIFF
--- a/src/source_map.js
+++ b/src/source_map.js
@@ -11,7 +11,8 @@ export class SourceMap {
 
     return paths.reduce((offsets, path) => {
       const currentSegment = this.sourceFiles[path];
-      const amountLines = currentSegment.match(/\r?\n/g).length;
+      const currentSegmentLines = currentSegment.match(/\r?\n/g);
+      const amountLines = currentSegmentLines ? currentSegmentLines.length : 0;
 
       const startLine = currentOffset;
       const endLine = currentOffset + amountLines;

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -16,6 +16,7 @@ describe('Configuration', () => {
   author: User!
 }
 
+
 type Query {
   something: String!
 }

--- a/test/source_map.js
+++ b/test/source_map.js
@@ -10,6 +10,9 @@ const sourceFiles = {
   username: String!
   email: String!
 }`,
+
+  'schema.graphql': 'schema { query: Query }',
+  'comment.graphql': 'type Comment { user: User! body: String! }',
 };
 
 describe('SourceMap', () => {
@@ -25,7 +28,9 @@ describe('SourceMap', () => {
 type User {
   username: String!
   email: String!
-}`
+}
+schema { query: Query }
+type Comment { user: User! body: String! }`
       );
     });
   });
@@ -41,6 +46,8 @@ type User {
       assert.equal('user.graphql', sourceMap.getOriginalPathForLine(5));
       assert.equal('user.graphql', sourceMap.getOriginalPathForLine(6));
       assert.equal('user.graphql', sourceMap.getOriginalPathForLine(7));
+      assert.equal('schema.graphql', sourceMap.getOriginalPathForLine(8));
+      assert.equal('comment.graphql', sourceMap.getOriginalPathForLine(9));
     });
   });
 });


### PR DESCRIPTION
Partially addresses #53 

The linter would previously crash when a `.graphql` file had no line breaks.

cc @mscharley