### PR TITLE
Catch and report GraphQL syntax errors

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -60,23 +60,7 @@ export function run(stdout, stdin, stderr, argv) {
   const rules = configuration.getRules();
   const schemaSourceMap = configuration.getSchemaSourceMap();
 
-  var errors;
-
-  try {
-    errors = validateSchemaDefinition(schema, rules);
-  } catch (e) {
-    if (e instanceof GraphQLError) {
-      stderr.write(
-        chalk.red(
-          `${figures.cross} An error occurred while parsing the GraphQL schema:\n\n`
-        )
-      );
-      stderr.write(String(e));
-      return 2;
-    }
-
-    throw e;
-  }
+  const errors = validateSchemaDefinition(schema, rules);
 
   const groupedErrors = groupErrorsBySchemaFilePath(errors, schemaSourceMap);
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -2,9 +2,19 @@ import { parse } from 'graphql';
 import { visit, visitInParallel } from 'graphql/language/visitor';
 import { validate } from 'graphql/validation';
 import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
+import { GraphQLError } from 'graphql/error';
 
 export function validateSchemaDefinition(schemaDefinition, rules) {
-  const ast = parse(schemaDefinition);
+  var ast;
+  try {
+    ast = parse(schemaDefinition);
+  } catch (e) {
+    if (e instanceof GraphQLError) {
+      return [e];
+    } else {
+      throw e;
+    }
+  }
   const schema = buildASTSchema(ast);
   const errors = validate(schema, ast, rules);
   const sortedErrors = sortErrors(errors);

--- a/test/runner.js
+++ b/test/runner.js
@@ -26,15 +26,21 @@ describe('Runner', () => {
   const mockStdin = { fd: openSync(fixturePath, 'r') };
 
   describe('run', () => {
-    it('returns exit code 2 when schema is invalid', () => {
+    it('returns exit code 1 when schema has a syntax error', () => {
       const argv = [
         'node',
         'lib/cli.js',
+        '--format',
+        'json',
         `${__dirname}/fixtures/invalid.graphql`,
       ];
 
       const exitCode = run(mockStdout, mockStdin, mockStderr, argv);
-      assert.equal(2, exitCode);
+      assert.equal(1, exitCode);
+
+      var errors = JSON.parse(stdout)['errors'];
+      assert(errors);
+      assert.equal(1, errors.length);
     });
 
     it('returns exit code 1 when there are errors', () => {

--- a/test/validator.js
+++ b/test/validator.js
@@ -21,6 +21,17 @@ describe('validateSchemaDefinition', () => {
 
     assert.deepEqual(errorLineNumbers.sort(), errorLineNumbers);
   });
+
+  it('catches and returns GraphQL syntax errors', () => {
+    const schemaPath = `${__dirname}/fixtures/invalid.graphql`;
+    const configuration = new Configuration({ schemaPaths: [schemaPath] });
+
+    const schemaDefinition = configuration.getSchema();
+
+    const errors = validateSchemaDefinition(schemaDefinition, []);
+
+    assert.equal(1, errors.length);
+  });
 });
 
 function DummyValidator(context) {


### PR DESCRIPTION
Syntax errors within the GraphQL schema definition will now be reported by the linter instead of crashing.

Before:

```
$ node lib/cli.js test/fixtures/invalid.graphql --format text
✖ An error occurred while parsing the GraphQL schema:

GraphQLError: Syntax Error GraphQL request (2:1) Expected Name, found <EOF>

1: type Query {
2:
   ^
```

After:

```
$ graphql-schema-linter test/fixtures/invalid.graphql --format text
test/fixtures/invalid.graphql
2:4 Syntax Error GraphQL request (2:1) Expected Name, found <EOF>  1: type Query { 2:     ^

✖ 1 error detected
```

cc @mscharley