### PR TITLE
Validate scalar type description

### DIFF
--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -22,6 +22,10 @@ export function TypesHaveDescriptions(context) {
       return false;
     },
 
+    ScalarTypeDefinition(node) {
+      validateTypeHasDescription(context, node, 'scalar');
+    },
+
     InterfaceTypeDefinition(node) {
       validateTypeHasDescription(context, node, 'interface');
     },

--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -1,6 +1,21 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
 import { GraphQLError } from 'graphql/error';
 
+function validateTypeHasDescription(context, node, typeKind) {
+  if (getDescription(node)) {
+    return;
+  }
+
+  const interfaceTypeName = node.name.value;
+
+  context.reportError(
+    new GraphQLError(
+      `The ${typeKind} type \`${interfaceTypeName}\` is missing a description.`,
+      [node]
+    )
+  );
+}
+
 export function TypesHaveDescriptions(context) {
   return {
     TypeExtensionDefinition(node) {
@@ -8,63 +23,19 @@ export function TypesHaveDescriptions(context) {
     },
 
     InterfaceTypeDefinition(node) {
-      if (getDescription(node)) {
-        return;
-      }
-
-      const interfaceTypeName = node.name.value;
-
-      context.reportError(
-        new GraphQLError(
-          `The interface type \`${interfaceTypeName}\` is missing a description.`,
-          [node]
-        )
-      );
+      validateTypeHasDescription(context, node, 'interface');
     },
 
     InputObjectTypeDefinition(node) {
-      if (getDescription(node)) {
-        return;
-      }
-
-      const interfaceTypeName = node.name.value;
-
-      context.reportError(
-        new GraphQLError(
-          `The input type \`${interfaceTypeName}\` is missing a description.`,
-          [node]
-        )
-      );
+      validateTypeHasDescription(context, node, 'input object');
     },
 
     UnionTypeDefinition(node) {
-      if (getDescription(node)) {
-        return;
-      }
-
-      const unionTypeName = node.name.value;
-
-      context.reportError(
-        new GraphQLError(
-          `The union type \`${unionTypeName}\` is missing a description.`,
-          [node]
-        )
-      );
+      validateTypeHasDescription(context, node, 'union');
     },
 
     ObjectTypeDefinition(node) {
-      if (getDescription(node)) {
-        return;
-      }
-
-      const objectTypeName = node.name.value;
-
-      context.reportError(
-        new GraphQLError(
-          `The object type \`${objectTypeName}\` is missing a description.`,
-          [node]
-        )
-      );
+      validateTypeHasDescription(context, node, 'object');
     },
   };
 }

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -7,6 +7,32 @@ import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 import { TypesHaveDescriptions } from '../../src/rules/types_have_descriptions';
 
 describe('TypesHaveDescriptions rule', () => {
+  it('catches scalar types that have no description', () => {
+    const ast = parse(`
+      # Query
+      type QueryRoot {
+        a: String
+      }
+
+      scalar DateTime
+
+      schema {
+        query: QueryRoot
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [TypesHaveDescriptions]);
+
+    assert.equal(errors.length, 1);
+
+    assert.equal(
+      errors[0].message,
+      'The scalar type `DateTime` is missing a description.'
+    );
+    assert.deepEqual(errors[0].locations, [{ line: 2, column: 7 }]);
+  });
+
   it('catches object types that have no description', () => {
     const ast = parse(`
       type QueryRoot {
@@ -53,7 +79,7 @@ describe('TypesHaveDescriptions rule', () => {
 
     assert.equal(
       errors[0].message,
-      'The input type `AddStar` is missing a description.'
+      'The input object type `AddStar` is missing a description.'
     );
     assert.deepEqual(errors[0].locations, [{ line: 7, column: 7 }]);
   });

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -30,7 +30,7 @@ describe('TypesHaveDescriptions rule', () => {
       errors[0].message,
       'The scalar type `DateTime` is missing a description.'
     );
-    assert.deepEqual(errors[0].locations, [{ line: 2, column: 7 }]);
+    assert.deepEqual(errors[0].locations, [{ line: 7, column: 7 }]);
   });
 
   it('catches object types that have no description', () => {


### PR DESCRIPTION
The `types-have-descriptions` rule was not validating scalar type definitions.

This now adds support for that.