### PR TITLE
Validate enum types have a description

### DIFF
--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -26,20 +26,24 @@ export function TypesHaveDescriptions(context) {
       validateTypeHasDescription(context, node, 'scalar');
     },
 
-    InterfaceTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'interface');
+    ObjectTypeDefinition(node) {
+      validateTypeHasDescription(context, node, 'object');
     },
 
-    InputObjectTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'input object');
+    InterfaceTypeDefinition(node) {
+      validateTypeHasDescription(context, node, 'interface');
     },
 
     UnionTypeDefinition(node) {
       validateTypeHasDescription(context, node, 'union');
     },
 
-    ObjectTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'object');
+    EnumTypeDefinition(node) {
+      validateTypeHasDescription(context, node, 'enum');
+    },
+
+    InputObjectTypeDefinition(node) {
+      validateTypeHasDescription(context, node, 'input object');
     },
   };
 }

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -7,6 +7,36 @@ import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 import { TypesHaveDescriptions } from '../../src/rules/types_have_descriptions';
 
 describe('TypesHaveDescriptions rule', () => {
+  it('catches enum types that have no description', () => {
+    const ast = parse(`
+      # Query
+      type QueryRoot {
+        a: String
+      }
+
+      enum STATUS {
+        DRAFT
+        PUBLISHED
+        HIDDEN
+      }
+
+      schema {
+        query: QueryRoot
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [TypesHaveDescriptions]);
+
+    assert.equal(errors.length, 1);
+
+    assert.equal(
+      errors[0].message,
+      'The enum type `STATUS` is missing a description.'
+    );
+    assert.deepEqual(errors[0].locations, [{ line: 7, column: 7 }]);
+  });
+
   it('catches scalar types that have no description', () => {
     const ast = parse(`
       # Query


### PR DESCRIPTION
The `types-have-descriptions` rule was not validating enum type definitions.

This now adds support for that.