### PR TITLE
Add input-object-values-have-descriptions rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ This rule will validate that all enum values are sorted alphabetically.
 
 ### `fields-have-descriptions`
 
-This rule will validate that all fields have a description.
+This rule will validate that object type fields and interface type fields have a description.
+
+### `input-object-values-have-descriptions`
+
+This rule will validate that input object values have a description.
 
 ### `types-are-capitalized`
 

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -4,6 +4,7 @@ import { TypesHaveDescriptions } from './types_have_descriptions.js';
 import { TypesAreCapitalized } from './types_are_capitalized.js';
 import { EnumValuesSortedAlphabetically } from './enum_values_sorted_alphabetically';
 import { EnumValuesAllCaps } from './enum_values_all_caps';
+import { InputObjectValuesHaveDescriptions } from '../../src/rules/input_object_values_have_descriptions';
 
 module.exports = [
   EnumValuesSortedAlphabetically,
@@ -12,4 +13,5 @@ module.exports = [
   DeprecationsHaveAReason,
   TypesHaveDescriptions,
   TypesAreCapitalized,
+  InputObjectValuesHaveDescriptions,
 ];

--- a/src/rules/input_object_values_have_descriptions.js
+++ b/src/rules/input_object_values_have_descriptions.js
@@ -1,0 +1,28 @@
+import { getDescription } from 'graphql/utilities/buildASTSchema';
+import { GraphQLError } from 'graphql/error';
+
+export function InputObjectValuesHaveDescriptions(context) {
+  return {
+    InputValueDefinition(node, key, parent, path, ancestors) {
+      if (getDescription(node)) {
+        return;
+      }
+
+      const inputValueName = node.name.value;
+      const parentNode = ancestors[ancestors.length - 1];
+
+      if (parentNode.kind != 'InputObjectTypeDefinition') {
+        return;
+      }
+
+      const inputObjectName = parentNode.name.value;
+
+      context.reportError(
+        new GraphQLError(
+          `The input value \`${inputObjectName}.${inputValueName}\` is missing a description.`,
+          [node]
+        )
+      );
+    },
+  };
+}

--- a/test/index.js
+++ b/test/index.js
@@ -17,6 +17,7 @@ require('./rules/enum_values_sorted_alphabetically');
 require('./rules/enum_values_all_caps');
 require('./rules/types_are_capitalized');
 require('./rules/defined_types_are_used');
+require('./rules/input_object_values_have_descriptions');
 require('./config/rc_file/test');
 require('./config/package_json/test');
 require('./config/js_file/test');

--- a/test/rules/input_object_values_have_descriptions.js
+++ b/test/rules/input_object_values_have_descriptions.js
@@ -1,0 +1,48 @@
+import assert from 'assert';
+import { parse } from 'graphql';
+import { visit, visitInParallel } from 'graphql/language/visitor';
+import { validate } from 'graphql/validation';
+import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
+
+import { InputObjectValuesHaveDescriptions } from '../../src/rules/input_object_values_have_descriptions';
+
+describe('InputObjectValuesHaveDescriptions rule', () => {
+  it('catches input object type values that have no description', () => {
+    const ast = parse(`
+      type Query {
+        hello: String
+      }
+
+      input User {
+        username: String
+
+        # Description
+        withDescription: String
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [InputObjectValuesHaveDescriptions]);
+
+    assert.equal(errors.length, 1);
+
+    assert.equal(
+      errors[0].message,
+      'The input value `User.username` is missing a description.'
+    );
+    assert.deepEqual(errors[0].locations, [{ line: 7, column: 9 }]);
+  });
+
+  it('ignores arguments that have no description', () => {
+    const ast = parse(`
+      type Query {
+        hello(argumentWithoutDescription: String): String
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [InputObjectValuesHaveDescriptions]);
+
+    assert.equal(errors.length, 0);
+  });
+});


### PR DESCRIPTION
Fixes #62

Example:

```graphql
input User {
  username: String

  # Description
  withDescription: String
}
```

This new rule would report `User.username` is missing a description.