### PR TITLE
Add enum-values-have-descriptions rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ This rule will validate that all deprecations have a reason.
 
 This rule will validate that all enum values are capitalized.
 
+### `enum-values-have-descriptions`
+
+This rule will validate that all enum values have a description.
+
 ### `enum-values-sorted-alphabetically`
 
 This rule will validate that all enum values are sorted alphabetically.

--- a/src/rules/enum_values_have_descriptions.js
+++ b/src/rules/enum_values_have_descriptions.js
@@ -1,0 +1,22 @@
+import { getDescription } from 'graphql/utilities/buildASTSchema';
+import { GraphQLError } from 'graphql/error';
+
+export function EnumValuesHaveDescriptions(context) {
+  return {
+    EnumValueDefinition(node, key, parent, path, ancestors) {
+      if (getDescription(node)) {
+        return;
+      }
+
+      const enumValue = node.name.value;
+      const parentName = ancestors[ancestors.length - 1].name.value;
+
+      context.reportError(
+        new GraphQLError(
+          `The enum value \`${parentName}.${enumValue}\` is missing a description.`,
+          [node]
+        )
+      );
+    },
+  };
+}

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -5,6 +5,7 @@ import { TypesAreCapitalized } from './types_are_capitalized.js';
 import { EnumValuesSortedAlphabetically } from './enum_values_sorted_alphabetically';
 import { EnumValuesAllCaps } from './enum_values_all_caps';
 import { InputObjectValuesHaveDescriptions } from '../../src/rules/input_object_values_have_descriptions';
+import { EnumValuesHaveDescriptions } from '../../src/rules/enum_values_have_descriptions';
 
 module.exports = [
   EnumValuesSortedAlphabetically,
@@ -14,4 +15,5 @@ module.exports = [
   TypesHaveDescriptions,
   TypesAreCapitalized,
   InputObjectValuesHaveDescriptions,
+  EnumValuesHaveDescriptions,
 ];

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ require('./rules/enum_values_all_caps');
 require('./rules/types_are_capitalized');
 require('./rules/defined_types_are_used');
 require('./rules/input_object_values_have_descriptions');
+require('./rules/enum_values_have_descriptions');
 require('./config/rc_file/test');
 require('./config/package_json/test');
 require('./config/js_file/test');

--- a/test/rules/enum_values_have_descriptions.js
+++ b/test/rules/enum_values_have_descriptions.js
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import { parse } from 'graphql';
+import { visit, visitInParallel } from 'graphql/language/visitor';
+import { validate } from 'graphql/validation';
+import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
+
+import { EnumValuesHaveDescriptions } from '../../src/rules/enum_values_have_descriptions';
+
+describe('EnumValuesHaveDescriptions rule', () => {
+  it('catches enum values that have no description', () => {
+    const ast = parse(`
+      type QueryRoot {
+        hello: String
+      }
+
+      schema {
+        query: QueryRoot
+      }
+
+      enum Status {
+        DRAFT
+
+        # Hidden
+        HIDDEN
+
+        PUBLISHED
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [EnumValuesHaveDescriptions]);
+
+    assert.equal(errors.length, 2);
+
+    assert.equal(
+      errors[0].message,
+      'The enum value `Status.DRAFT` is missing a description.'
+    );
+    assert.deepEqual(errors[0].locations, [{ line: 11, column: 9 }]);
+
+    assert.equal(
+      errors[1].message,
+      'The enum value `Status.PUBLISHED` is missing a description.'
+    );
+    assert.deepEqual(errors[1].locations, [{ line: 16, column: 9 }]);
+  });
+});


### PR DESCRIPTION
Fixes #63

Example:

```graphql
enum Status {
  DRAFT

  # Hidden
  HIDDEN

  PUBLISHED
}
```

This new rule would report `Status.DRAFT` and `Status.PUBLISHED` are missing descriptions.