### PR TITLE
Add sanity check to Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ language: node_js
 node_js:
   - "node"
   - "lts/*"
+before_script:
+  - yarn prepare
+script:
+  - yarn test
+  - node lib/cli.js --version
+  - node lib/cli.js test/fixtures/valid.graphql
 notifications:
   email: false


### PR DESCRIPTION
This pull request adds one last safety net to the build so that we don't 🚢 broken releases like in #68.

Once the test suite passes, Travis CI will attempt to run `graphql-schema-linter --version` and validate a simple schema definition.