### PR TITLE
Include name of rule that caused error in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ The following formatters are currently available: `text`, `json`.
 Sample output:
 
 ```
-5:1 The object type `QueryRoot` is missing a description.
-6:3 The field `QueryRoot.a` is missing a description.
+5:1 The object type `QueryRoot` is missing a description.  types-have-descriptions
+6:3 The field `QueryRoot.a` is missing a description.      fields-have-descriptions
 
 2 errors detected
 ```
@@ -194,7 +194,8 @@ Sample output:
         "line": 5,
         "column": 1,
         "file": "schema.graphql"
-      }
+      },
+      "rule": "types-have-descriptions"
     },
     {
       "message": "The field `QueryRoot.a` is missing a description.",
@@ -202,7 +203,8 @@ Sample output:
         "line": 6,
         "column": 3,
         "file": "schema.graphql"
-      }
+      },
+      "rule": "fields-have-descriptions"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "husky": "^0.14.3",
     "lint-staged": "^4.0.3",
     "mocha": "^3.4.2",
-    "prettier": "^1.6.0"
+    "prettier": "^1.6.0",
+    "strip-ansi": "^4.0.0"
   },
   "babel": {
     "presets": ["es2015", "stage-0"]

--- a/src/formatters/json_formatter.js
+++ b/src/formatters/json_formatter.js
@@ -14,6 +14,7 @@ export default function JSONFormatter(errorsGroupedByFile) {
             column: error.locations[0].column,
             file: file,
           },
+          rule: error.ruleName,
         };
       })
     );

--- a/src/formatters/text_formatter.js
+++ b/src/formatters/text_formatter.js
@@ -23,7 +23,7 @@ function generateErrorsForFile(file, errors) {
     return {
       location: chalk.dim(`${location.line}:${location.column * 4}`),
       message: error.message,
-      // TODO: Add rule name
+      rule: chalk.dim(` ${error.ruleName}`),
     };
   });
 

--- a/src/rules/defined_types_are_used.js
+++ b/src/rules/defined_types_are_used.js
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function DefinedTypesAreUsed(context) {
   var ignoredTypes = ['Query', 'Mutatation', 'Subscription'];
@@ -28,7 +28,8 @@ export function DefinedTypesAreUsed(context) {
         definedTypes.forEach(node => {
           if (!referencedTypes.has(node.name.value)) {
             context.reportError(
-              new GraphQLError(
+              new ValidationError(
+                'defined-types-are-used',
                 `The type \`${node.name.value}\` is defined in the ` +
                   `schema but not used anywhere.`,
                 [node]

--- a/src/rules/deprecations_have_a_reason.js
+++ b/src/rules/deprecations_have_a_reason.js
@@ -1,5 +1,5 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function DeprecationsHaveAReason(context) {
   return {
@@ -18,7 +18,8 @@ export function DeprecationsHaveAReason(context) {
       const parentName = ancestors[ancestors.length - 1].name.value;
 
       context.reportError(
-        new GraphQLError(
+        new ValidationError(
+          'deprecations-have-a-reason',
           `The field \`${parentName}.${fieldName}\` is deprecated but has no deprecation reason.`,
           [deprecatedDirective]
         )
@@ -40,7 +41,8 @@ export function DeprecationsHaveAReason(context) {
       const parentName = ancestors[ancestors.length - 1].name.value;
 
       context.reportError(
-        new GraphQLError(
+        new ValidationError(
+          'deprecations-have-a-reason',
           `The enum value \`${parentName}.${enumValueName}\` is deprecated but has no deprecation reason.`,
           [deprecatedDirective]
         )

--- a/src/rules/enum_values_all_caps.js
+++ b/src/rules/enum_values_all_caps.js
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function EnumValuesAllCaps(context) {
   return {
@@ -8,7 +8,8 @@ export function EnumValuesAllCaps(context) {
 
       if (enumValueName !== enumValueName.toUpperCase()) {
         context.reportError(
-          new GraphQLError(
+          new ValidationError(
+            'enum-values-all-caps',
             `The enum value \`${parentName}.${enumValueName}\` should be uppercase.`,
             [node]
           )

--- a/src/rules/enum_values_have_descriptions.js
+++ b/src/rules/enum_values_have_descriptions.js
@@ -1,5 +1,5 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function EnumValuesHaveDescriptions(context) {
   return {
@@ -12,7 +12,8 @@ export function EnumValuesHaveDescriptions(context) {
       const parentName = ancestors[ancestors.length - 1].name.value;
 
       context.reportError(
-        new GraphQLError(
+        new ValidationError(
+          'enum-values-have-descriptions',
           `The enum value \`${parentName}.${enumValue}\` is missing a description.`,
           [node]
         )

--- a/src/rules/enum_values_sorted_alphabetically.js
+++ b/src/rules/enum_values_sorted_alphabetically.js
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function EnumValuesSortedAlphabetically(context) {
   return {
@@ -15,7 +15,8 @@ export function EnumValuesSortedAlphabetically(context) {
 
       if (!arraysEqual(enumValues, enumValues.slice().sort())) {
         context.reportError(
-          new GraphQLError(
+          new ValidationError(
+            'enum-values-sorted-alphabetically',
             'The enum `' +
               node.name.value +
               '` should be sorted alphabetically.',

--- a/src/rules/fields_have_descriptions.js
+++ b/src/rules/fields_have_descriptions.js
@@ -1,5 +1,5 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function FieldsHaveDescriptions(context) {
   return {
@@ -12,7 +12,8 @@ export function FieldsHaveDescriptions(context) {
       const parentName = ancestors[ancestors.length - 1].name.value;
 
       context.reportError(
-        new GraphQLError(
+        new ValidationError(
+          'fields-have-descriptions',
           `The field \`${parentName}.${fieldName}\` is missing a description.`,
           [node]
         )

--- a/src/rules/input_object_values_have_descriptions.js
+++ b/src/rules/input_object_values_have_descriptions.js
@@ -1,5 +1,5 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function InputObjectValuesHaveDescriptions(context) {
   return {
@@ -18,7 +18,8 @@ export function InputObjectValuesHaveDescriptions(context) {
       const inputObjectName = parentNode.name.value;
 
       context.reportError(
-        new GraphQLError(
+        new ValidationError(
+          'input-object-values-have-descriptions',
           `The input value \`${inputObjectName}.${inputValueName}\` is missing a description.`,
           [node]
         )

--- a/src/rules/types_are_capitalized.js
+++ b/src/rules/types_are_capitalized.js
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 export function TypesAreCapitalized(context) {
   return {
@@ -6,7 +6,8 @@ export function TypesAreCapitalized(context) {
       const typeName = node.name.value;
       if (typeName[0] == typeName[0].toLowerCase()) {
         context.reportError(
-          new GraphQLError(
+          new ValidationError(
+            'types-are-capitalized',
             `The object type \`${typeName}\` should start with a capital letter.`,
             [node.name]
           )
@@ -18,7 +19,8 @@ export function TypesAreCapitalized(context) {
       const typeName = node.name.value;
       if (typeName[0] == typeName[0].toLowerCase()) {
         context.reportError(
-          new GraphQLError(
+          new ValidationError(
+            'types-are-capitalized',
             `The interface type \`${typeName}\` should start with a capital letter.`,
             [node.name]
           )

--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -1,5 +1,5 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
-import { GraphQLError } from 'graphql/error';
+import { ValidationError } from '../validation_error';
 
 function validateTypeHasDescription(context, node, typeKind) {
   if (getDescription(node)) {
@@ -9,7 +9,8 @@ function validateTypeHasDescription(context, node, typeKind) {
   const interfaceTypeName = node.name.value;
 
   context.reportError(
-    new GraphQLError(
+    new ValidationError(
+      'types-have-descriptions',
       `The ${typeKind} type \`${interfaceTypeName}\` is missing a description.`,
       [node]
     )

--- a/src/runner.js
+++ b/src/runner.js
@@ -3,7 +3,6 @@ import { rules } from './index.js';
 import { version } from '../package.json';
 import { Command } from 'commander';
 import { Configuration } from './configuration.js';
-import { GraphQLError } from 'graphql/error';
 import figures from 'figures';
 import chalk from 'chalk';
 

--- a/src/validation_error.js
+++ b/src/validation_error.js
@@ -1,0 +1,9 @@
+import { GraphQLError } from 'graphql/error';
+
+export class ValidationError extends GraphQLError {
+  constructor(ruleName, message, nodes) {
+    super(message, nodes);
+
+    this.ruleName = ruleName;
+  }
+}

--- a/test/rules/defined_types_are_used.js
+++ b/test/rules/defined_types_are_used.js
@@ -23,6 +23,7 @@ describe('DefinedTypesAreUsed rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'defined-types-are-used');
     assert.equal(
       errors[0].message,
       'The type `A` is defined in the schema but not used anywhere.'
@@ -46,6 +47,7 @@ describe('DefinedTypesAreUsed rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'defined-types-are-used');
     assert.equal(
       errors[0].message,
       'The type `A` is defined in the schema but not used anywhere.'
@@ -67,6 +69,7 @@ describe('DefinedTypesAreUsed rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'defined-types-are-used');
     assert.equal(
       errors[0].message,
       'The type `A` is defined in the schema but not used anywhere.'
@@ -90,6 +93,7 @@ describe('DefinedTypesAreUsed rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'defined-types-are-used');
     assert.equal(
       errors[0].message,
       'The type `A` is defined in the schema but not used anywhere.'
@@ -111,6 +115,7 @@ describe('DefinedTypesAreUsed rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'defined-types-are-used');
     assert.equal(
       errors[0].message,
       'The type `A` is defined in the schema but not used anywhere.'

--- a/test/rules/deprecations_have_a_reason.js
+++ b/test/rules/deprecations_have_a_reason.js
@@ -29,6 +29,7 @@ describe('DeprecationsHaveAReason rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'deprecations-have-a-reason');
     assert.equal(
       errors[0].message,
       'The field `A.deprecatedWithoutReason` is deprecated but has no deprecation reason.'
@@ -58,6 +59,7 @@ describe('DeprecationsHaveAReason rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'deprecations-have-a-reason');
     assert.equal(
       errors[0].message,
       'The field `A.deprecatedWithoutReason` is deprecated but has no deprecation reason.'
@@ -87,6 +89,7 @@ describe('DeprecationsHaveAReason rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'deprecations-have-a-reason');
     assert.equal(
       errors[0].message,
       'The enum value `A.deprecatedWithoutReason` is deprecated but has no deprecation reason.'

--- a/test/rules/enum_values_all_caps.js
+++ b/test/rules/enum_values_all_caps.js
@@ -16,6 +16,7 @@ describe('EnumValuesAllCaps rule', () => {
 
     assert.equal(errors.length, 2);
 
+    assert.equal(errors[0].ruleName, 'enum-values-all-caps');
     assert.equal(
       errors[0].message,
       'The enum value `Stage.aaa` should be uppercase.'

--- a/test/rules/enum_values_have_descriptions.js
+++ b/test/rules/enum_values_have_descriptions.js
@@ -32,12 +32,14 @@ describe('EnumValuesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 2);
 
+    assert.equal(errors[0].ruleName, 'enum-values-have-descriptions');
     assert.equal(
       errors[0].message,
       'The enum value `Status.DRAFT` is missing a description.'
     );
     assert.deepEqual(errors[0].locations, [{ line: 11, column: 9 }]);
 
+    assert.equal(errors[1].ruleName, 'enum-values-have-descriptions');
     assert.equal(
       errors[1].message,
       'The enum value `Status.PUBLISHED` is missing a description.'

--- a/test/rules/enum_values_sorted_alphabetically.js
+++ b/test/rules/enum_values_sorted_alphabetically.js
@@ -19,6 +19,7 @@ describe('EnumValuesSortedAlphabetically rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'enum-values-sorted-alphabetically');
     assert.equal(
       errors[0].message,
       'The enum `Stage` should be sorted alphabetically.'

--- a/test/rules/fields_have_descriptions.js
+++ b/test/rules/fields_have_descriptions.js
@@ -27,12 +27,14 @@ describe('FieldsHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 2);
 
+    assert.equal(errors[0].ruleName, 'fields-have-descriptions');
     assert.equal(
       errors[0].message,
       'The field `QueryRoot.withoutDescription` is missing a description.'
     );
     assert.deepEqual(errors[0].locations, [{ line: 3, column: 9 }]);
 
+    assert.equal(errors[1].ruleName, 'fields-have-descriptions');
     assert.equal(
       errors[1].message,
       'The field `QueryRoot.withoutDescriptionAgain` is missing a description.'

--- a/test/rules/input_object_values_have_descriptions.js
+++ b/test/rules/input_object_values_have_descriptions.js
@@ -26,6 +26,7 @@ describe('InputObjectValuesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'input-object-values-have-descriptions');
     assert.equal(
       errors[0].message,
       'The input value `User.username` is missing a description.'

--- a/test/rules/types_are_capitalized.js
+++ b/test/rules/types_are_capitalized.js
@@ -27,6 +27,7 @@ describe('TypesAreCapitalized rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-are-capitalized');
     assert.equal(
       errors[0].message,
       'The object type `a` should start with a capital letter.'
@@ -54,6 +55,7 @@ describe('TypesAreCapitalized rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-are-capitalized');
     assert.equal(
       errors[0].message,
       'The interface type `a` should start with a capital letter.'

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -30,6 +30,7 @@ describe('TypesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-have-descriptions');
     assert.equal(
       errors[0].message,
       'The enum type `STATUS` is missing a description.'
@@ -56,6 +57,7 @@ describe('TypesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-have-descriptions');
     assert.equal(
       errors[0].message,
       'The scalar type `DateTime` is missing a description.'
@@ -79,6 +81,7 @@ describe('TypesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-have-descriptions');
     assert.equal(
       errors[0].message,
       'The object type `QueryRoot` is missing a description.'
@@ -107,6 +110,7 @@ describe('TypesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-have-descriptions');
     assert.equal(
       errors[0].message,
       'The input object type `AddStar` is missing a description.'
@@ -135,6 +139,7 @@ describe('TypesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-have-descriptions');
     assert.equal(
       errors[0].message,
       'The interface type `A` is missing a description.'
@@ -171,6 +176,7 @@ describe('TypesHaveDescriptions rule', () => {
 
     assert.equal(errors.length, 1);
 
+    assert.equal(errors[0].ruleName, 'types-have-descriptions');
     assert.equal(
       errors[0].message,
       'The union type `AB` is missing a description.'

--- a/test/runner.js
+++ b/test/runner.js
@@ -171,6 +171,7 @@ describe('Runner', () => {
         `${__dirname}/fixtures/schema/schema.graphql`,
         errors[0].location.file
       );
+      assert.equal(errors[0].rule, 'fields-have-descriptions');
 
       assert.equal(
         'The field `User.username` is missing a description.',
@@ -181,6 +182,7 @@ describe('Runner', () => {
         `${__dirname}/fixtures/schema/user.graphql`,
         errors[1].location.file
       );
+      assert.equal(errors[1].rule, 'fields-have-descriptions');
 
       assert.equal(
         'The field `User.email` is missing a description.',
@@ -191,6 +193,7 @@ describe('Runner', () => {
         `${__dirname}/fixtures/schema/user.graphql`,
         errors[2].location.file
       );
+      assert.equal(errors[2].rule, 'fields-have-descriptions');
 
       assert.equal(
         'The field `Query.viewer` is missing a description.',
@@ -201,6 +204,7 @@ describe('Runner', () => {
         `${__dirname}/fixtures/schema/user.graphql`,
         errors[3].location.file
       );
+      assert.equal(errors[3].rule, 'fields-have-descriptions');
 
       assert.equal(
         'The field `Comment.body` is missing a description.',
@@ -211,6 +215,7 @@ describe('Runner', () => {
         `${__dirname}/fixtures/schema/comment.graphql`,
         errors[4].location.file
       );
+      assert.equal(errors[4].rule, 'fields-have-descriptions');
 
       assert.equal(
         'The field `Comment.author` is missing a description.',
@@ -221,6 +226,7 @@ describe('Runner', () => {
         `${__dirname}/fixtures/schema/comment.graphql`,
         errors[5].location.file
       );
+      assert.equal(errors[5].rule, 'fields-have-descriptions');
     });
   });
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { run } from '../src/runner.js';
 import { openSync } from 'fs';
+const stripAnsi = require('strip-ansi');
 
 describe('Runner', () => {
   var stdout;
@@ -69,6 +70,46 @@ describe('Runner', () => {
       assert.equal(0, exitCode);
     });
 
+    it('validates a single schema file and outputs in text', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'text',
+        '--rules',
+        'fields-have-descriptions',
+        fixturePath,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      const expected =
+        `${fixturePath}\n` +
+        '2:12 The field `Query.a` is missing a description.  fields-have-descriptions\n' +
+        '\n' +
+        '✖ 1 error detected\n';
+
+      assert.equal(expected, stripAnsi(stdout));
+    });
+
+    it('validates schema passed in via stdin and outputs in json', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'json',
+        '--rules',
+        'fields-have-descriptions',
+        '--stdin',
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      var errors = JSON.parse(stdout)['errors'];
+      assert(errors);
+      assert.equal(1, errors.length);
+    });
+
     it('validates a single schema file and outputs in json', () => {
       const argv = [
         'node',
@@ -83,8 +124,16 @@ describe('Runner', () => {
       run(mockStdout, mockStdin, mockStderr, argv);
 
       var errors = JSON.parse(stdout)['errors'];
-      assert(errors);
-      assert.equal(1, errors.length);
+      assert.deepEqual(
+        [
+          {
+            message: 'The field `Query.a` is missing a description.',
+            location: { column: 3, line: 2, file: fixturePath },
+            rule: 'fields-have-descriptions',
+          },
+        ],
+        errors
+      );
     });
 
     it('validates schema passed in via stdin and outputs in json', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,18 +1014,14 @@ cosmiconfig@^1.1.0:
     pinkie-promise "^2.0.0"
     require-from-string "^1.1.0"
 
-cosmiconfig@davidtheclark/cosmiconfig#6eb3cc85d3a435e6b9e252b341e601960312f410:
-  version "2.2.2"
-  resolved "https://codeload.github.com/davidtheclark/cosmiconfig/tar.gz/6eb3cc85d3a435e6b9e252b341e601960312f410"
+cosmiconfig@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
   dependencies:
     is-directory "^0.3.1"
-    is-promise "^2.1.0"
     js-yaml "^3.9.0"
-    minimist "^1.2.0"
-    os-homedir "^1.0.1"
-    parse-json "^2.2.0"
-    please-upgrade-node "^3.0.1"
-    require-from-string "^1.1.0"
+    parse-json "^3.0.0"
+    require-from-string "^2.0.1"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -1124,7 +1120,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
@@ -2233,6 +2229,12 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
+  dependencies:
+    error-ex "^1.3.1"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -2262,10 +2264,6 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-please-upgrade-node@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
 
 pluralize@^4.0.0:
   version "4.0.0"
@@ -2433,6 +2431,10 @@ request@^2.81.0:
 require-from-string@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
+require-from-string@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
 
 require-uncached@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Fixes #7 

**Examples:**

```
$ graphql-schema-linter schema.graphql
schema.graphql
7:4   The object type `user` is missing a description.                          types-have-descriptions
7:24  The object type `user` should start with a capital letter.                types-are-capitalized
8:12  The field `user.fullName` is missing a description.                       fields-have-descriptions
11:84 The field `user.firstName` is deprecated but has no deprecation reason.   deprecations-have-a-reason
27:52 The object type `user` should start with a capital letter.                types-are-capitalized
28:12 The field `user.b` is missing a description.                              fields-have-descriptions
31:4  The enum `Stage` should be sorted alphabetically.                         enum-values-sorted-alphabetically
31:4  The enum type `Stage` is missing a description.                           types-have-descriptions
32:12 The enum value `Stage.b` should be uppercase.                             enum-values-all-caps
32:12 The enum value `Stage.b` is missing a description.                        enum-values-have-descriptions
33:12 The enum value `Stage.Z` is missing a description.                        enum-values-have-descriptions
34:12 The enum value `Stage.A` is missing a description.                        enum-values-have-descriptions
```

```
$ graphql-schema-linter --format json schema.graphql

{
    "errors": [
        {
            "location": {
                "column": 1,
                "file": "schema.graphql",
                "line": 7
            },
            "message": "The object type `user` is missing a description.",
            "rule": "types-have-descriptions"
        },
      ...
  ]
}
```

**TODO:**

- [x] Update `README.md`
- [x] Add tests for `JSONFormatter` and `TextFormatter`
