### PR TITLE
types-are-capitalized should ignore underscores

### DIFF
--- a/src/rules/types_are_capitalized.js
+++ b/src/rules/types_are_capitalized.js
@@ -1,13 +1,20 @@
 import { GraphQLError } from 'graphql/error';
 
 export function TypesAreCapitalized(context) {
+  var ignoredChars = ['_'];
+
   return {
     ObjectTypeDefinition(node) {
       const typeName = node.name.value;
-      if (typeName[0] == typeName[0].toLowerCase()) {
+      if (
+        !ignoredChars.includes(typeName[0]) &&
+        typeName[0] == typeName[0].toLowerCase()
+      ) {
         context.reportError(
           new GraphQLError(
-            `The object type \`${typeName}\` should start with a capital letter.`,
+            `The object type \`${
+              typeName
+            }\` should start with a capital letter.`,
             [node.name]
           )
         );
@@ -16,10 +23,15 @@ export function TypesAreCapitalized(context) {
 
     InterfaceTypeDefinition(node) {
       const typeName = node.name.value;
-      if (typeName[0] == typeName[0].toLowerCase()) {
+      if (
+        !ignoredChars.includes(typeName[0]) &&
+        typeName[0] == typeName[0].toLowerCase()
+      ) {
         context.reportError(
           new GraphQLError(
-            `The interface type \`${typeName}\` should start with a capital letter.`,
+            `The interface type \`${
+              typeName
+            }\` should start with a capital letter.`,
             [node.name]
           )
         );

--- a/test/rules/types_are_capitalized.js
+++ b/test/rules/types_are_capitalized.js
@@ -60,4 +60,28 @@ describe('TypesAreCapitalized rule', () => {
     );
     assert.deepEqual(errors[0].locations, [{ line: 6, column: 17 }]);
   });
+
+  it('ignores types that are part of the introspection system (aka __)', () => {
+    const ast = parse(`
+      type QueryRoot {
+        a: String
+      }
+
+      schema {
+        query: QueryRoot
+      }
+
+      type __EnumValue {
+        deprecationReason: String
+        description: String
+        isDeprecated: Boolean!
+        name: String!
+      }
+    `);
+
+    const schema = buildASTSchema(ast);
+    const errors = validate(schema, ast, [TypesAreCapitalized]);
+
+    assert.equal(errors.length, 0);
+  });
 });


### PR DESCRIPTION
Types that are part of the introspection system are prefixed by double underscores and they are failing to lint properly with this rule. This is taking the opinion that this is what most people would want. Thoughts?