### PR TITLE
Add defined-types-are-used to index.js

### DIFF
--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -6,6 +6,7 @@ import { EnumValuesSortedAlphabetically } from './enum_values_sorted_alphabetica
 import { EnumValuesAllCaps } from './enum_values_all_caps';
 import { InputObjectValuesHaveDescriptions } from './input_object_values_have_descriptions';
 import { EnumValuesHaveDescriptions } from './enum_values_have_descriptions';
+import { DefinedTypesAreUsed } from './defined_types_are_used.js';
 
 module.exports = [
   EnumValuesSortedAlphabetically,
@@ -16,4 +17,5 @@ module.exports = [
   TypesAreCapitalized,
   InputObjectValuesHaveDescriptions,
   EnumValuesHaveDescriptions,
+  DefinedTypesAreUsed,
 ];


### PR DESCRIPTION
It doesn't look as though this was available due to it not being added to index.js.