### PR TITLE
Better test coverage around formatters

### DIFF
--- a/src/formatters/text_formatter.js
+++ b/src/formatters/text_formatter.js
@@ -21,7 +21,7 @@ function generateErrorsForFile(file, errors) {
     const location = error.locations[0];
 
     return {
-      location: chalk.dim(`${location.line}:${location.column * 4}`),
+      location: chalk.dim(`${location.line}:${location.column}`),
       message: error.message,
       rule: chalk.dim(` ${error.ruleName}`),
     };

--- a/test/formatters/json_formatter.js
+++ b/test/formatters/json_formatter.js
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import JSONFormatter from '../../src/formatters/json_formatter';
+
+describe('JSONFormatter', () => {
+  it('returns an array of errors in JSON format', () => {
+    const errors = {
+      'schema/query.graphql': [
+        {
+          message:
+            'The field `Query.users` is deprecated but has no deprecation reason.',
+          locations: [{ line: 4, column: 20 }],
+          ruleName: 'deprecations-have-a-reason',
+        },
+      ],
+
+      'schema/user.graphql': [
+        {
+          message: 'The field `User.email` is missing a description.',
+          locations: [{ line: 3, column: 3 }],
+          ruleName: 'fields-have-descriptions',
+        },
+      ],
+    };
+
+    assert.equal(
+      JSONFormatter(errors),
+      JSON.stringify({
+        errors: [
+          {
+            message:
+              'The field `Query.users` is deprecated but has no deprecation reason.',
+            location: {
+              line: 4,
+              column: 20,
+              file: 'schema/query.graphql',
+            },
+            rule: 'deprecations-have-a-reason',
+          },
+          {
+            message: 'The field `User.email` is missing a description.',
+            location: {
+              line: 3,
+              column: 3,
+              file: 'schema/user.graphql',
+            },
+            rule: 'fields-have-descriptions',
+          },
+        ],
+      })
+    );
+  });
+
+  it('returns an empty array when there is no errors', () => {
+    assert.equal(JSONFormatter({}), JSON.stringify({ errors: [] }));
+  });
+});

--- a/test/formatters/text_formatter.js
+++ b/test/formatters/text_formatter.js
@@ -1,0 +1,67 @@
+import assert from 'assert';
+import TextFormatter from '../../src/formatters/text_formatter';
+import figures from 'figures';
+const stripAnsi = require('strip-ansi');
+
+describe('TextFormatter', () => {
+  it('returns a summary when there are no errors', () => {
+    const expected = '\n' + `\n${figures.tick} 0 errors detected\n\n`;
+
+    assert.equal(stripAnsi(TextFormatter({})), expected);
+  });
+
+  it('returns error and singular summary when there is one error', () => {
+    const errors = {
+      'schema/query.graphql': [
+        {
+          message:
+            'The field `Query.users` is deprecated but has no deprecation reason.',
+          locations: [{ line: 4, column: 20 }],
+          ruleName: 'deprecations-have-a-reason',
+        },
+      ],
+    };
+
+    const expected =
+      '' +
+      'schema/query.graphql\n' +
+      '4:20 The field `Query.users` is deprecated but has no deprecation reason.  deprecations-have-a-reason\n' +
+      '\n' +
+      `${figures.cross} 1 error detected\n`;
+
+    assert.equal(stripAnsi(TextFormatter(errors)), expected);
+  });
+
+  it('returns errors and plural summary when there is more than one error', () => {
+    const errors = {
+      'schema/query.graphql': [
+        {
+          message:
+            'The field `Query.users` is deprecated but has no deprecation reason.',
+          locations: [{ line: 4, column: 20 }],
+          ruleName: 'deprecations-have-a-reason',
+        },
+      ],
+
+      'schema/user.graphql': [
+        {
+          message: 'The field `User.email` is missing a description.',
+          locations: [{ line: 3, column: 3 }],
+          ruleName: 'fields-have-descriptions',
+        },
+      ],
+    };
+
+    const expected =
+      '' +
+      'schema/query.graphql\n' +
+      '4:20 The field `Query.users` is deprecated but has no deprecation reason.  deprecations-have-a-reason\n' +
+      '\n' +
+      'schema/user.graphql\n' +
+      '3:3 The field `User.email` is missing a description.  fields-have-descriptions\n' +
+      '\n' +
+      `${figures.cross} 2 errors detected\n`;
+
+    assert.equal(stripAnsi(TextFormatter(errors)), expected);
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,8 @@ require('./rules/types_are_capitalized');
 require('./rules/defined_types_are_used');
 require('./rules/input_object_values_have_descriptions');
 require('./rules/enum_values_have_descriptions');
+require('./formatters/json_formatter');
+require('./formatters/text_formatter');
 require('./config/rc_file/test');
 require('./config/package_json/test');
 require('./config/js_file/test');

--- a/test/runner.js
+++ b/test/runner.js
@@ -85,7 +85,7 @@ describe('Runner', () => {
 
       const expected =
         `${fixturePath}\n` +
-        '2:12 The field `Query.a` is missing a description.  fields-have-descriptions\n' +
+        '2:3 The field `Query.a` is missing a description.  fields-have-descriptions\n' +
         '\n' +
         '✖ 1 error detected\n';
 


### PR DESCRIPTION
This PR adds better test coverage around the `TextFormatter` and `JSONFormatter`.

I also discovered an issue with the `TextFormatter`. It was not reporting the right `column` number due to a typo.