### PR TITLE
Add JUnitFormatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "columnify": "^1.5.4",
     "commander": "^2.11.0",
     "cosmiconfig": "^3.1.0",
+    "escape-html": "^1.0.3",
     "figures": "^2.0.0",
     "glob": "^7.1.2",
     "graphql": "^0.10.1",

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -8,12 +8,13 @@ import defaultRules from './rules/index.js';
 import { SourceMap } from './source_map.js';
 import JSONFormatter from './formatters/json_formatter.js';
 import TextFormatter from './formatters/text_formatter.js';
+import JUnitFormatter from './formatters/junit_formatter.js';
 
 export class Configuration {
   /*
     options:
       - configDirectory: path to begin searching for config files
-      - format: (required) `text` | `json`
+      - format: (required) `text` | `json` | `junit`
       - rules: [string array] whitelist rules
       - schemaPaths: [string array] file(s) to read schema from
       - stdin: [boolean] pass schema via stdin?
@@ -75,6 +76,8 @@ export class Configuration {
         return JSONFormatter;
       case 'text':
         return TextFormatter;
+      case 'junit':
+        return JUnitFormatter;
 
       // TODO raise when invalid formatter
     }

--- a/src/formatters/junit_formatter.js
+++ b/src/formatters/junit_formatter.js
@@ -1,0 +1,34 @@
+const escapeHtml = require('escape-html');
+
+export default function JUnitFormatter(errorsGroupedByFile) {
+  const files = Object.keys(errorsGroupedByFile);
+
+  var xml = '<?xml version="1.0" encoding="utf-8"?>\n';
+
+  xml = xml + '<testsuites>\n';
+
+  files.forEach(file => {
+    var errorsCount = errorsGroupedByFile[file].length;
+
+    xml =
+      xml +
+      `  <testsuite name="${file}" time="0" tests="${errorsCount}" errors="${errorsCount}">\n`;
+
+    errorsGroupedByFile[file].forEach(error => {
+      xml =
+        xml +
+        `    <testcase name="Line ${error.locations[0].line}, Column ${error
+          .locations[0].column}: ${error.ruleName}">\n`;
+      xml =
+        xml +
+        `      <failure type="error">${escapeHtml(error.message)}</failure>\n`;
+      xml = xml + `    </testcase>\n`;
+    });
+
+    xml = xml + `  </testsuite>\n`;
+  });
+
+  xml = xml + '</testsuites>\n';
+
+  return xml;
+}

--- a/src/runner.js
+++ b/src/runner.js
@@ -15,7 +15,7 @@ export function run(stdout, stdin, stderr, argv) {
     )
     .option(
       '-f, --format <format>',
-      'choose the output format of the report. Possible values: json, text'
+      'choose the output format of the report. Possible values: json, text, junit'
     )
     .option(
       '-s, --stdin',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,6 +1126,10 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
Fixes #64 

@mscharley here's a WIP of the `JUnitFormatter` based on [eslint](https://github.com/eslint/eslint/blob/f4a65c6ceabcd2e1843ec38370fe8019392530ed/lib/formatters/junit.js) and [tlint](https://github.com/eslint/eslint/blob/f4a65c6ceabcd2e1843ec38370fe8019392530ed/lib/formatters/junit.js).

Here's a sample output:

```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites>
  <testsuite name="test/fixtures/schema/comment.graphql" time="0" tests="4" errors="4">
    <testcase name="Line 1, Column 1: types-have-descriptions">
      <failure type="error">The object type `Comment` is missing a description.</failure>
    </testcase>
    <testcase name="Line 1, Column 1: defined-types-are-used">
      <failure type="error">The type `Comment` is defined in the schema but not used anywhere.</failure>
    </testcase>
    <testcase name="Line 2, Column 3: fields-have-descriptions">
      <failure type="error">The field `Comment.body` is missing a description.</failure>
    </testcase>
    <testcase name="Line 3, Column 3: fields-have-descriptions">
      <failure type="error">The field `Comment.author` is missing a description.</failure>
    </testcase>
  </testsuite>
  <testsuite name="test/fixtures/schema/schema.graphql" time="0" tests="2" errors="2">
    <testcase name="Line 1, Column 1: types-have-descriptions">
      <failure type="error">The object type `Query` is missing a description.</failure>
    </testcase>
    <testcase name="Line 2, Column 3: fields-have-descriptions">
      <failure type="error">The field `Query.something` is missing a description.</failure>
    </testcase>
  </testsuite>
  <testsuite name="test/fixtures/schema/user.graphql" time="0" tests="4" errors="4">
    <testcase name="Line 1, Column 1: types-have-descriptions">
      <failure type="error">The object type `User` is missing a description.</failure>
    </testcase>
    <testcase name="Line 2, Column 3: fields-have-descriptions">
      <failure type="error">The field `User.username` is missing a description.</failure>
    </testcase>
    <testcase name="Line 3, Column 3: fields-have-descriptions">
      <failure type="error">The field `User.email` is missing a description.</failure>
    </testcase>
    <testcase name="Line 7, Column 3: fields-have-descriptions">
      <failure type="error">The field `Query.viewer` is missing a description.</failure>
    </testcase>
  </testsuite>
</testsuites>
```

If you want to give it a try, you should be able to clone this repository and then run `yarn prepare` (or `npm run-script prepare`) to generate `lib/`. You can then run `node lib/cli.js --format junit path/to/schema.graphql`.