### PR TITLE
Add configuration validation

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -127,7 +127,8 @@ export class Configuration {
         field: 'format',
         type: 'error',
       });
-    } else if (misConfiguredRuleNames.length > 0) {
+    }
+    if (misConfiguredRuleNames.length > 0) {
       issues.push({
         message: `The following rule(s) are invalid: ${misConfiguredRuleNames.join(
           ', '

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -75,15 +75,10 @@ export class Configuration {
         return JSONFormatter;
       case 'text':
         return TextFormatter;
-
-      // TODO raise when invalid formatter
     }
   }
 
   getRules() {
-    // TODO validate that all specified rules actually exist. This way we can
-    //      prevent people from making typos.
-
     var rules = defaultRules;
     var specifiedRules;
 
@@ -111,6 +106,38 @@ export class Configuration {
     }
 
     return rules;
+  }
+
+  validate() {
+    const issues = [];
+
+    const defaultRuleNames = defaultRules.map(rule => rule.name);
+    var misConfiguredRuleNames = []
+      .concat(
+        this.options.only || [],
+        this.options.except || [],
+        this.options.rules || []
+      )
+      .map(toUpperCamelCase)
+      .filter(name => defaultRuleNames.indexOf(name) == -1);
+
+    if (this.getFormatter() == null) {
+      issues.push({
+        message: `The output format '${this.options.format}' is invalid`,
+        field: 'format',
+        type: 'error',
+      });
+    } else if (misConfiguredRuleNames.length > 0) {
+      issues.push({
+        message: `The following rule(s) are invalid: ${misConfiguredRuleNames.join(
+          ', '
+        )}`,
+        field: 'rules',
+        type: 'warning',
+      });
+    }
+
+    return issues;
   }
 }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -72,6 +72,7 @@ export function run(stdout, stdin, stderr, argv) {
     if (issues.some(issue => issue.type == 'error')) {
       return 1;
     }
+    return 2;
   }
 
   const schema = configuration.getSchema();

--- a/src/runner.js
+++ b/src/runner.js
@@ -54,6 +54,26 @@ export function run(stdout, stdin, stderr, argv) {
     stdin.fd
   );
 
+  const issues = configuration.validate();
+
+  if (issues.length > 0) {
+    issues.map(issue => {
+      var prefix;
+      if (issue.type == 'error') {
+        prefix = `${chalk.red(figures.cross)} Error`;
+      } else {
+        prefix = `${chalk.yellow(figures.warning)} Warning`;
+      }
+      stderr.write(
+        `${prefix} on ${chalk.bold(issue.field)}: ${issue.message}\n\n`
+      );
+    });
+
+    if (issues.some(issue => issue.type == 'error')) {
+      return 1;
+    }
+  }
+
   const schema = configuration.getSchema();
   const formatter = configuration.getFormatter();
   const rules = configuration.getRules();

--- a/src/runner.js
+++ b/src/runner.js
@@ -56,22 +56,19 @@ export function run(stdout, stdin, stderr, argv) {
 
   const issues = configuration.validate();
 
-  if (issues.length > 0) {
-    issues.map(issue => {
-      var prefix;
-      if (issue.type == 'error') {
-        prefix = `${chalk.red(figures.cross)} Error`;
-      } else {
-        prefix = `${chalk.yellow(figures.warning)} Warning`;
-      }
-      stderr.write(
-        `${prefix} on ${chalk.bold(issue.field)}: ${issue.message}\n\n`
-      );
-    });
-
-    if (issues.some(issue => issue.type == 'error')) {
-      return 1;
+  issues.map(issue => {
+    var prefix;
+    if (issue.type == 'error') {
+      prefix = `${chalk.red(figures.cross)} Error`;
+    } else {
+      prefix = `${chalk.yellow(figures.warning)} Warning`;
     }
+    stderr.write(
+      `${prefix} on ${chalk.bold(issue.field)}: ${issue.message}\n\n`
+    );
+  });
+
+  if (issues.some(issue => issue.type == 'error')) {
     return 2;
   }
 

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -197,5 +197,16 @@ extend type Query {
       assert.equal(issues[0].field, 'rules');
       assert.equal(issues[0].type, 'warning');
     });
+
+    it('warns and errors when multiple issues arise configured', () => {
+      const configuration = new Configuration({
+        except: ['NoRuleOfMine', 'FieldsHaveDescriptions'],
+        format: 'xml',
+      });
+
+      const issues = configuration.validate();
+
+      assert.equal(issues.length, 2);
+    });
   });
 });

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -167,4 +167,35 @@ extend type Query {
       );
     });
   });
+
+  describe('validate', () => {
+    it('errors when an invalid format is configured', () => {
+      const configuration = new Configuration({
+        format: 'xml',
+      });
+
+      const issues = configuration.validate();
+
+      assert.equal(issues.length, 1);
+      assert.equal(issues[0].message, "The output format 'xml' is invalid");
+      assert.equal(issues[0].field, 'format');
+      assert.equal(issues[0].type, 'error');
+    });
+
+    it('warns when an invalid rule is configured', () => {
+      const configuration = new Configuration({
+        except: ['NoRuleOfMine', 'FieldsHaveDescriptions'],
+      });
+
+      const issues = configuration.validate();
+
+      assert.equal(issues.length, 1);
+      assert.equal(
+        issues[0].message,
+        'The following rule(s) are invalid: NoRuleOfMine'
+      );
+      assert.equal(issues[0].field, 'rules');
+      assert.equal(issues[0].type, 'warning');
+    });
+  });
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -293,7 +293,7 @@ describe('Runner', () => {
 
       const exitCode = run(mockStdout, mockStdin, mockStderr, argv);
       assert(stderr.indexOf("The output format 'xml' is invalid") >= 0);
-      assert.equal(1, exitCode);
+      assert.equal(2, exitCode);
     });
 
     it('warns but continues if a rule is unknown', () => {

--- a/test/runner.js
+++ b/test/runner.js
@@ -296,7 +296,7 @@ describe('Runner', () => {
       assert.equal(1, exitCode);
     });
 
-    it('warns but conitunes if a rule is unknown', () => {
+    it('warns but continues if a rule is unknown', () => {
       const argv = [
         'node',
         'lib/cli.js',

--- a/test/runner.js
+++ b/test/runner.js
@@ -277,5 +277,41 @@ describe('Runner', () => {
       );
       assert.equal(errors[5].rule, 'fields-have-descriptions');
     });
+
+    it('fails and exits if the output format is unknown', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'xml',
+        '--rules',
+        'fields-have-descriptions',
+        `${__dirname}/fixtures/valid.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      const exitCode = run(mockStdout, mockStdin, mockStderr, argv);
+      assert(stderr.indexOf("The output format 'xml' is invalid") >= 0);
+      assert.equal(1, exitCode);
+    });
+
+    it('warns but conitunes if a rule is unknown', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--rules',
+        'no-rule-of-mine,fields-have-descriptions',
+        `${__dirname}/fixtures/valid.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      const exitCode = run(mockStdout, mockStdin, mockStderr, argv);
+      assert(
+        stderr.indexOf('The following rule(s) are invalid: NoRuleOfMine') >= 0
+      );
+      assert.equal(0, exitCode);
+    });
   });
 });


### PR DESCRIPTION
This adds 2 kinds of configuration validation:
 1. A valid formatter is configured
 2. Valid rules are configured

This validation runs before real work gets started on the linting. It has 2 flavors: error and/or warning-both print developer friendly (hopefully) messages and errors halt execution.

With this structure in place, I think other configuration issues (like #38) would be pretty easily handled.

Example usage:
<img width="1001" alt="screen shot 2017-12-03 at 2 35 32 pm" src="https://user-images.githubusercontent.com/245096/33530765-6c15b406-d839-11e7-9965-caa1553d184d.png">
<img width="924" alt="screen shot 2017-12-03 at 2 34 48 pm" src="https://user-images.githubusercontent.com/245096/33530766-6e89f878-d839-11e7-88dc-dad839fc0370.png">
