### PR TITLE
fix: resolve to absolute paths to handle duplicates

### DIFF
--- a/src/configuration.js
+++ b/src/configuration.js
@@ -51,7 +51,11 @@ export class Configuration {
         })
         .reduce((a, b) => {
           return a.concat(b);
-        }, []);
+        }, [])
+        // Resolve paths to absolute paths so that including the same file
+        // multiple times is not treated as different files
+        .map(p => path.resolve(p));
+
       var segments = getSchemaSegmentsFromFiles(paths);
 
       this.sourceMap = new SourceMap(segments);

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -4,6 +4,7 @@ import { Configuration } from '../src/configuration.js';
 import JSONFormatter from '../src/formatters/json_formatter.js';
 import TextFormatter from '../src/formatters/text_formatter.js';
 import { openSync, readFileSync } from 'fs';
+import { relative as pathRelative } from 'path';
 
 describe('Configuration', () => {
   describe('getSchema', () => {
@@ -52,6 +53,25 @@ extend type Query {
       const fd = openSync(fixturePath, 'r');
 
       const configuration = new Configuration({ args: [], stdin: true }, fd);
+      assert.equal(
+        configuration.getSchema(),
+        readFileSync(fixturePath).toString('utf8')
+      );
+    });
+
+    it('normalizes schema files paths', () => {
+      const fixturePath = `${__dirname}/fixtures/schema.graphql`;
+      const duplicatePath = pathRelative(
+        process.cwd(),
+        `${__dirname}/fixtures/schema.graphql`
+      );
+
+      assert.notEqual(fixturePath, duplicatePath);
+
+      const configuration = new Configuration({
+        schemaPaths: [fixturePath, duplicatePath],
+      });
+
       assert.equal(
         configuration.getSchema(),
         readFileSync(fixturePath).toString('utf8')


### PR DESCRIPTION
Related: #78 

Case:

As mentioned in #78, when we have lint-staged as the entire file-list,

```json
{
  "*.gql": [ "graphql-schema-linter src/types/*.gql", "git add" ]
}
```

the file list that the cli receives is 

```js
[
  "src/types/a.gql",
  "src/types/b.gql",
  // and if a.gql is staged
  "/Users/user/workspace/project/src/types/a.gql"
]
```

and since the schema is stored as `Object<path, schema>`, the staged files have two schemas and that conflicts and gives an error - `Error: Type "A" was defined more than once`

This PR fixes the above issue of duplicated files by resolving files to absolute paths initially.