### PR TITLE
Rename RelayConnectionsHaveFields to RelayConnectionTypesSpec

### DIFF
--- a/src/rules/relay_connection_types_spec.js
+++ b/src/rules/relay_connection_types_spec.js
@@ -1,7 +1,7 @@
 import { ValidationError } from '../validation_error';
 const MANDATORY_FIELDS = ['pageInfo', 'edges'];
 
-export function RelayConnectionsHaveFields(context) {
+export function RelayConnectionTypesSpec(context) {
   return {
     ObjectTypeDefinition(node) {
       const typeName = node.name.value;
@@ -16,7 +16,7 @@ export function RelayConnectionsHaveFields(context) {
       if (missingFields.length) {
         context.reportError(
           new ValidationError(
-            'relay-connections-have-fields',
+            'relay-connection-types-spec',
             `Connection \`${typeName}\` is missing the following field${missingFields.length >
             1
               ? 's'

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ require('./rules/defined_types_are_used');
 require('./rules/input_object_values_have_descriptions');
 require('./rules/input_object_values_are_camel_cased');
 require('./rules/enum_values_have_descriptions');
-require('./rules/relay_connections_have_fields');
+require('./rules/relay_connection_types_spec');
 require('./formatters/json_formatter');
 require('./formatters/text_formatter');
 require('./config/rc_file/test');

--- a/test/rules/relay_connection_types_spec.js
+++ b/test/rules/relay_connection_types_spec.js
@@ -1,10 +1,10 @@
-import { RelayConnectionsHaveFields } from '../../src/rules/relay_connections_have_fields';
+import { RelayConnectionTypesSpec } from '../../src/rules/relay_connection_types_spec';
 import { expectFailsRule, expectPassesRule } from '../assertions';
 
-describe('RelayConnectionsHaveFields  rule', () => {
+describe('RelayConnectionTypesSpec  rule', () => {
   it('catches object types that have missing fields', () => {
     expectFailsRule(
-      RelayConnectionsHaveFields,
+      RelayConnectionTypesSpec,
       `
       type BadConnection {
         a: String
@@ -22,9 +22,8 @@ describe('RelayConnectionsHaveFields  rule', () => {
 
   it('accepts object types with the correct fields.', () => {
     expectPassesRule(
-      RelayConnectionsHaveFields,
+      RelayConnectionTypesSpec,
       `
-      
       type BetterConnection {
         pageInfo: String
         edges: Int
@@ -34,7 +33,7 @@ describe('RelayConnectionsHaveFields  rule', () => {
   });
   it('ignores interface types that have missing fields', () => {
     expectPassesRule(
-      RelayConnectionsHaveFields,
+      RelayConnectionTypesSpec,
       `
       interface BadConnection {
         a: String


### PR DESCRIPTION
As discussed in https://github.com/cjoudrey/graphql-schema-linter/pull/89#issuecomment-362842207, this will allow us to have a single rule for each section of the Relay spec.

For example, we can have a rule that validates [section 2 (connection types)](https://facebook.github.io/relay/graphql/connections.htm#sec-Connection-Types), one for [section 3 (edge types)](https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types) and another for [section 4 (connection arguments)](https://facebook.github.io/relay/graphql/connections.htm#sec-Arguments).