### PR TITLE
Ensure types that end in Connection are objects

### DIFF
--- a/src/rules/relay_connection_types_spec.js
+++ b/src/rules/relay_connection_types_spec.js
@@ -2,7 +2,25 @@ import { ValidationError } from '../validation_error';
 const MANDATORY_FIELDS = ['pageInfo', 'edges'];
 
 export function RelayConnectionTypesSpec(context) {
+  var ensureNameDoesNotEndWithConnection = node => {
+    if (node.name.value.match(/Connection$/)) {
+      context.reportError(
+        new ValidationError(
+          'relay-connection-types-spec',
+          `Types that end in \`Connection\` must be an object type as per the relay spec. \`${node
+            .name.value}\` is not an object type.`,
+          [node]
+        )
+      );
+    }
+  };
+
   return {
+    ScalarTypeDefinition: ensureNameDoesNotEndWithConnection,
+    InterfaceTypeDefinition: ensureNameDoesNotEndWithConnection,
+    UnionTypeDefinition: ensureNameDoesNotEndWithConnection,
+    EnumTypeDefinition: ensureNameDoesNotEndWithConnection,
+    InputObjectTypeDefinition: ensureNameDoesNotEndWithConnection,
     ObjectTypeDefinition(node) {
       const typeName = node.name.value;
       if (!typeName.endsWith('Connection')) {

--- a/test/rules/relay_connection_types_spec.js
+++ b/test/rules/relay_connection_types_spec.js
@@ -31,14 +31,119 @@ describe('RelayConnectionTypesSpec  rule', () => {
     `
     );
   });
-  it('ignores interface types that have missing fields', () => {
+
+  it('ignores types that are not objects', () => {
     expectPassesRule(
       RelayConnectionTypesSpec,
       `
-      interface BadConnection {
+      scalar A
+
+      interface B {
         a: String
       }
+
+      union C = F
+
+      enum D {
+        SOMETHING
+      }
+
+      input E {
+        a: String!
+      }
+
+      type F {
+        a: String!
+      }
     `
+    );
+  });
+
+  it('catches types that end in Connection but that are not objects', () => {
+    expectFailsRule(
+      RelayConnectionTypesSpec,
+      `
+      scalar AConnection
+
+      interface BConnection {
+        a: String!
+      }
+
+      type F {
+        a: String!
+      }
+      union CConnection = F
+
+      enum DConnection {
+        SOMETHING
+      }
+
+      input EConnection {
+        a: String!
+      }
+      `,
+      [
+        {
+          locations: [
+            {
+              column: 7,
+              line: 2,
+            },
+          ],
+          message:
+            'Types that end in `Connection` must be an object type as per the relay spec. `AConnection` is not an object type.',
+          path: [undefined],
+          ruleName: 'relay-connection-types-spec',
+        },
+        {
+          locations: [
+            {
+              column: 7,
+              line: 4,
+            },
+          ],
+          message:
+            'Types that end in `Connection` must be an object type as per the relay spec. `BConnection` is not an object type.',
+          path: [undefined],
+          ruleName: 'relay-connection-types-spec',
+        },
+        {
+          locations: [
+            {
+              column: 7,
+              line: 11,
+            },
+          ],
+          message:
+            'Types that end in `Connection` must be an object type as per the relay spec. `CConnection` is not an object type.',
+          path: [undefined],
+          ruleName: 'relay-connection-types-spec',
+        },
+        {
+          locations: [
+            {
+              column: 7,
+              line: 13,
+            },
+          ],
+          message:
+            'Types that end in `Connection` must be an object type as per the relay spec. `DConnection` is not an object type.',
+          path: [undefined],
+          ruleName: 'relay-connection-types-spec',
+        },
+        {
+          locations: [
+            {
+              column: 7,
+              line: 17,
+            },
+          ],
+          message:
+            'Types that end in `Connection` must be an object type as per the relay spec. `EConnection` is not an object type.',
+          path: [undefined],
+          ruleName: 'relay-connection-types-spec',
+        },
+      ]
     );
   });
 });


### PR DESCRIPTION
From [the Relay spec](https://facebook.github.io/relay/graphql/connections.htm#sec-Connection-Types):

> Any type whose name ends in “Connection” is considered by Relay to be a Connection Type. Connection types must be an “Object” as defined in the “Type System” section of the GraphQL Specification.