### PR TITLE
Validate return types of edges and pageInfo fields

### DIFF
--- a/src/rules/relay_connection_types_spec.js
+++ b/src/rules/relay_connection_types_spec.js
@@ -1,4 +1,6 @@
 import { ValidationError } from '../validation_error';
+import { print } from 'graphql/language/printer';
+
 const MANDATORY_FIELDS = ['pageInfo', 'edges'];
 
 export function RelayConnectionTypesSpec(context) {
@@ -39,6 +41,37 @@ export function RelayConnectionTypesSpec(context) {
             1
               ? 's'
               : ''}: ${missingFields.join(', ')}.`,
+            [node]
+          )
+        );
+        return;
+      }
+
+      const edgesField = node.fields.find(field => field.name.value == 'edges');
+      const edgesFieldType = edgesField.type;
+
+      if (edgesFieldType.kind != 'ListType') {
+        context.reportError(
+          new ValidationError(
+            'relay-connection-types-spec',
+            `The \`${typeName}.edges\` field must return a list of edges not \`${print(
+              edgesFieldType
+            )}\`.`,
+            [node]
+          )
+        );
+      }
+
+      const pageInfoField = node.fields.find(
+        field => field.name.value == 'pageInfo'
+      );
+      const printedPageInfoFieldType = print(pageInfoField.type);
+
+      if (printedPageInfoFieldType != 'PageInfo!') {
+        context.reportError(
+          new ValidationError(
+            'relay-connection-types-spec',
+            `The \`${typeName}.pageInfo\` field must return a non-null \`PageInfo\` object not \`${printedPageInfoFieldType}\``,
             [node]
           )
         );

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -35,5 +35,8 @@ export function expectPassesRule(rule, schemaSDL, expectedErrors = []) {
   const schema = buildASTSchema(ast);
   const errors = validate(schema, ast, [rule]);
 
-  assert(errors.length == 0, "Expected rule to pass but didn't");
+  assert(
+    errors.length == 0,
+    `Expected rule to pass but didn't got these errors:\n\n${errors.join('\n')}`
+  );
 }

--- a/test/rules/relay_connection_types_spec.js
+++ b/test/rules/relay_connection_types_spec.js
@@ -24,11 +24,76 @@ describe('RelayConnectionTypesSpec  rule', () => {
     expectPassesRule(
       RelayConnectionTypesSpec,
       `
+      type PageInfo {
+        a: String
+      }
+
+      type Edge {
+        a: String
+      }
+
       type BetterConnection {
-        pageInfo: String
-        edges: Int
+        pageInfo: PageInfo!
+        edges: [Edge]
       }
     `
+    );
+  });
+
+  it('catches edges fields that are not lists of edges', () => {
+    expectFailsRule(
+      RelayConnectionTypesSpec,
+      `
+      type PageInfo {
+        a: String
+      }
+
+      type Edge {
+        a: String
+      }
+
+      type BadConnection {
+        pageInfo: PageInfo!
+        edges: String
+      }
+
+      type AnotherBadConnection {
+        pageInfo: String
+        edges: [Edge]
+      }
+
+      type YetAnotherBadConnection {
+        pageInfo: String!
+        edges: [Edge]
+      }
+    `,
+      [
+        {
+          message:
+            'The `BadConnection.edges` field must return a list of edges not `String`.',
+          locations: [{ line: 10, column: 7 }],
+        },
+        {
+          message:
+            'The `AnotherBadConnection.pageInfo` field must return a non-null `PageInfo` object not `String`',
+          locations: [
+            {
+              column: 7,
+              line: 15,
+            },
+          ],
+        },
+        {
+          message:
+            'The `YetAnotherBadConnection.pageInfo` field must return a non-null `PageInfo` object not `String!`',
+          locations: [
+            {
+              column: 7,
+              line: 20,
+            },
+          ],
+        },
+      ]
     );
   });
 


### PR DESCRIPTION
From [the Relay spec](https://facebook.github.io/relay/graphql/connections.htm#sec-Connection-Types):

> A “Connection Type” must contain a field called edges. This field must return a list type that wraps an edge type, where the requirements of an edge type are defined in the “Edge Types” section below.

In this rule we will validate that `edges` is in fact a list type, but we'll validate the requirements of edges types in a different rule that will cover [section 3 of the spec](https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types).

> A “Connection Type” must contain a field called `pageInfo`. This field must return a non‐null  `PageInfo` object, as defined in the “PageInfo” section below.

In this rule we only validate that `pageInfo` is of type `PageInfo!`. The actual requirements of the `PageInfo` object will be validated in a different rule that will cover [section 5 of the spec](https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo).