### PR TITLE
Fix a few bugs in defined-types-are-used rule

### DIFF
--- a/src/rules/defined_types_are_used.js
+++ b/src/rules/defined_types_are_used.js
@@ -19,13 +19,29 @@ export function DefinedTypesAreUsed(context) {
     EnumTypeDefinition: recordDefinedType,
     InputObjectTypeDefinition: recordDefinedType,
 
-    NamedType: node => {
+    NamedType: (node, key, parent, path, ancestors) => {
       referencedTypes.add(node.name.value);
     },
 
     Document: {
       leave: node => {
         definedTypes.forEach(node => {
+          if (node.kind == 'ObjectTypeDefinition') {
+            let implementedInterfaces = node.interfaces.map(node => {
+              return node.name.value;
+            });
+
+            let anyReferencedInterfaces = implementedInterfaces.some(
+              interfaceName => {
+                return referencedTypes.has(interfaceName);
+              }
+            );
+
+            if (anyReferencedInterfaces) {
+              return;
+            }
+          }
+
           if (!referencedTypes.has(node.name.value)) {
             context.reportError(
               new ValidationError(

--- a/src/rules/defined_types_are_used.js
+++ b/src/rules/defined_types_are_used.js
@@ -1,7 +1,7 @@
 import { ValidationError } from '../validation_error';
 
 export function DefinedTypesAreUsed(context) {
-  var ignoredTypes = ['Query', 'Mutatation', 'Subscription'];
+  var ignoredTypes = ['Query', 'Mutation', 'Subscription'];
   var definedTypes = [];
   var referencedTypes = new Set();
 

--- a/test/rules/defined_types_are_used.js
+++ b/test/rules/defined_types_are_used.js
@@ -20,6 +20,33 @@ describe('DefinedTypesAreUsed rule', () => {
     );
   });
 
+  it('catches object types that are extended but not used', () => {
+    expectFailsRule(
+      DefinedTypesAreUsed,
+      `
+      type A {
+        a: String
+      }
+
+      extend type A {
+        b: String
+      }
+    `,
+      [
+        {
+          message:
+            'The type `A` is defined in the schema but not used anywhere.',
+          locations: [{ line: 2, column: 7 }],
+        },
+        {
+          message:
+            'The type `A` is defined in the schema but not used anywhere.',
+          locations: [{ line: 6, column: 14 }],
+        },
+      ]
+    );
+  });
+
   it('catches interface types that are defined but not used', () => {
     expectFailsRule(
       DefinedTypesAreUsed,

--- a/test/rules/defined_types_are_used.js
+++ b/test/rules/defined_types_are_used.js
@@ -97,7 +97,7 @@ describe('DefinedTypesAreUsed rule', () => {
       }
 
       type A {
-        a: A
+        a: String
       }
 
       union B = A | Query
@@ -119,7 +119,6 @@ describe('DefinedTypesAreUsed rule', () => {
 
       type A implements Node {
         id: ID!
-        a: A
       }
     `
     );

--- a/test/rules/defined_types_are_used.js
+++ b/test/rules/defined_types_are_used.js
@@ -156,4 +156,37 @@ describe('DefinedTypesAreUsed rule', () => {
     `
     );
   });
+
+  it('ignores unreferenced Mutation object type', () => {
+    expectPassesRule(
+      DefinedTypesAreUsed,
+      `
+      type Mutation {
+        a: String
+      }
+    `
+    );
+  });
+
+  it('ignores unreferenced Subscription object type', () => {
+    expectPassesRule(
+      DefinedTypesAreUsed,
+      `
+      type Subscription {
+        a: String
+      }
+    `
+    );
+  });
+
+  it('ignores unreferenced Query object type', () => {
+    expectPassesRule(
+      DefinedTypesAreUsed,
+      `
+      extend type Query {
+        a: String
+      }
+    `
+    );
+  });
 });


### PR DESCRIPTION
This pull request fixes two issues with the `defined-types-are-used` rule.

- `Mutation` object type shouldn't be reported as unused as GraphQL defaults to the `Mutation` object type as the schema's mutation root.

- An object type that implements an interface that is referenced is ok. For example, if an object implements `Node` and there is a field of type `node: Node` in `type Query`.

This pull request also better test coverage around some edge cases.