### PR TITLE
Descriptions as strings in GraphQL SDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Options:
 
     schema definition will be read from STDIN instead of specified file
 
+  --comment-descriptions
+
+    use old way of defining descriptions in GraphQL SDL
+
   -c, --config-direction <path>
 
     path to begin searching for config files

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cosmiconfig": "^3.1.0",
     "figures": "^2.0.0",
     "glob": "^7.1.2",
-    "graphql": "^0.10.1",
+    "graphql": "^0.13.0",
     "graphql-config": "^1.0.0",
     "lodash": "^4.17.4"
   },

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -16,9 +16,14 @@ export class Configuration {
       - schemaPaths: [string array] file(s) to read schema from
       - customRulePaths: [string array] path to additional custom rules to be loaded
       - stdin: [boolean] pass schema via stdin?
+      - commentDescriptions: [boolean] use old way of defining descriptions in GraphQL SDL
   */
   constructor(options = {}, stdinFd = null) {
-    const defaultOptions = { format: 'text', customRulePaths: [] };
+    const defaultOptions = {
+      format: 'text',
+      customRulePaths: [],
+      commentDescriptions: false,
+    };
     const configOptions = loadOptionsFromConfig(options.configDirectory);
 
     // TODO Get configs from .graphqlconfig file
@@ -31,6 +36,10 @@ export class Configuration {
     this.rulePaths = this.options.customRulePaths.concat(
       path.join(__dirname, 'rules/*.js')
     );
+  }
+
+  getCommentDescriptions() {
+    return this.options.commentDescriptions;
   }
 
   getSchema() {

--- a/src/rules/enum_values_have_descriptions.js
+++ b/src/rules/enum_values_have_descriptions.js
@@ -1,10 +1,14 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
 import { ValidationError } from '../validation_error';
 
-export function EnumValuesHaveDescriptions(context) {
+export function EnumValuesHaveDescriptions(configuration, context) {
   return {
     EnumValueDefinition(node, key, parent, path, ancestors) {
-      if (getDescription(node)) {
+      if (
+        getDescription(node, {
+          commentDescriptions: configuration.getCommentDescriptions(),
+        })
+      ) {
         return;
       }
 

--- a/src/rules/fields_have_descriptions.js
+++ b/src/rules/fields_have_descriptions.js
@@ -1,10 +1,14 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
 import { ValidationError } from '../validation_error';
 
-export function FieldsHaveDescriptions(context) {
+export function FieldsHaveDescriptions(configuration, context) {
   return {
     FieldDefinition(node, key, parent, path, ancestors) {
-      if (getDescription(node)) {
+      if (
+        getDescription(node, {
+          commentDescriptions: configuration.getCommentDescriptions(),
+        })
+      ) {
         return;
       }
 

--- a/src/rules/input_object_values_have_descriptions.js
+++ b/src/rules/input_object_values_have_descriptions.js
@@ -1,10 +1,14 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
 import { ValidationError } from '../validation_error';
 
-export function InputObjectValuesHaveDescriptions(context) {
+export function InputObjectValuesHaveDescriptions(configuration, context) {
   return {
     InputValueDefinition(node, key, parent, path, ancestors) {
-      if (getDescription(node)) {
+      if (
+        getDescription(node, {
+          commentDescriptions: configuration.getCommentDescriptions(),
+        })
+      ) {
         return;
       }
 

--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -1,8 +1,12 @@
 import { getDescription } from 'graphql/utilities/buildASTSchema';
 import { ValidationError } from '../validation_error';
 
-function validateTypeHasDescription(context, node, typeKind) {
-  if (getDescription(node)) {
+function validateTypeHasDescription(configuration, context, node, typeKind) {
+  if (
+    getDescription(node, {
+      commentDescriptions: configuration.getCommentDescriptions(),
+    })
+  ) {
     return;
   }
 
@@ -17,34 +21,34 @@ function validateTypeHasDescription(context, node, typeKind) {
   );
 }
 
-export function TypesHaveDescriptions(context) {
+export function TypesHaveDescriptions(configuration, context) {
   return {
     TypeExtensionDefinition(node) {
       return false;
     },
 
     ScalarTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'scalar');
+      validateTypeHasDescription(configuration, context, node, 'scalar');
     },
 
     ObjectTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'object');
+      validateTypeHasDescription(configuration, context, node, 'object');
     },
 
     InterfaceTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'interface');
+      validateTypeHasDescription(configuration, context, node, 'interface');
     },
 
     UnionTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'union');
+      validateTypeHasDescription(configuration, context, node, 'union');
     },
 
     EnumTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'enum');
+      validateTypeHasDescription(configuration, context, node, 'enum');
     },
 
     InputObjectTypeDefinition(node) {
-      validateTypeHasDescription(context, node, 'input object');
+      validateTypeHasDescription(configuration, context, node, 'input object');
     },
   };
 }

--- a/src/runner.js
+++ b/src/runner.js
@@ -84,8 +84,7 @@ export function run(stdout, stdin, stderr, argv) {
   const rules = configuration.getRules();
   const schemaSourceMap = configuration.getSchemaSourceMap();
 
-  const errors = validateSchemaDefinition(schema, rules);
-
+  const errors = validateSchemaDefinition(schema, rules, configuration);
   const groupedErrors = groupErrorsBySchemaFilePath(errors, schemaSourceMap);
 
   stdout.write(formatter(groupedErrors));

--- a/src/runner.js
+++ b/src/runner.js
@@ -28,6 +28,10 @@ export function run(stdout, stdin, stderr, argv) {
       '-p, --custom-rule-paths <paths>',
       'path to additional custom rules to be loaded. Example: rules/*.js'
     )
+    .option(
+      '--comment-descriptions',
+      'use old way of defining descriptions in GraphQL SDL'
+    )
     // DEPRECATED - This code should be removed in v1.0.0.
     .option(
       '-o, --only <rules>',
@@ -134,6 +138,10 @@ function getOptionsFromCommander(commander) {
 
   if (commander.customRulePaths) {
     options.customRulePaths = commander.customRulePaths.split(',');
+  }
+
+  if (commander.commentDescriptions) {
+    options.commentDescriptions = commander.commentDescriptions;
   }
 
   if (commander.args && commander.args.length) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -18,7 +18,9 @@ export function validateSchemaDefinition(
       throw e;
     }
   }
-  const schema = buildASTSchema(ast);
+  const schema = buildASTSchema(ast, {
+    commentDescriptions: configuration.getCommentDescriptions(),
+  });
 
   const rulesWithConfiguration = rules.map(rule => {
     return ruleWithConfiguration(rule, configuration);

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -262,4 +262,16 @@ extend type Query {
       assert.equal(issues.length, 2);
     });
   });
+
+  describe('getCommentDescriptions', () => {
+    it('defaults to false', () => {
+      const configuration = new Configuration({});
+      assert.equal(configuration.getCommentDescriptions(), false);
+    });
+
+    it('returns specified value', () => {
+      const configuration = new Configuration({ commentDescriptions: true });
+      assert.equal(configuration.getCommentDescriptions(), true);
+    });
+  });
 });

--- a/test/fixtures/animal.graphql
+++ b/test/fixtures/animal.graphql
@@ -1,21 +1,23 @@
-# Base query
+"Base query"
 type Query {
-  # Animal Viewing
+  "Animal Viewing"
   viewer: Animal!
 }
 
-# Animal
+"Animal"
 type Animal {
-  # name
+  "name"
   name: String!
-  # type
+
+  "type"
   types: [AnimalTypes]
 }
 
-# Animal type enum
+"Animal type enum"
 enum AnimalTypes {
-  # meow
+  "meow"
   CAT_ENUM
-  # woof
+
+  "woof"
   DOG_ENUM
 }

--- a/test/fixtures/schema.comment-descriptions.graphql
+++ b/test/fixtures/schema.comment-descriptions.graphql
@@ -1,0 +1,7 @@
+# Query
+type Query {
+  a: String
+
+  # B
+  b: String
+}

--- a/test/fixtures/valid.graphql
+++ b/test/fixtures/valid.graphql
@@ -1,5 +1,5 @@
-# Query
+"Query"
 type Query {
-  # a
+  "a"
   a: String!
 }

--- a/test/rules/enum_values_have_descriptions.js
+++ b/test/rules/enum_values_have_descriptions.js
@@ -1,5 +1,8 @@
 import { EnumValuesHaveDescriptions } from '../../src/rules/enum_values_have_descriptions';
-import { expectFailsRule } from '../assertions';
+import {
+  expectFailsRule,
+  expectPassesRuleWithConfiguration,
+} from '../assertions';
 
 describe('EnumValuesHaveDescriptions rule', () => {
   it('catches enum values that have no description', () => {
@@ -9,7 +12,7 @@ describe('EnumValuesHaveDescriptions rule', () => {
       enum Status {
         DRAFT
 
-        # Hidden
+        "Hidden"
         HIDDEN
 
         PUBLISHED
@@ -26,6 +29,19 @@ describe('EnumValuesHaveDescriptions rule', () => {
           locations: [{ line: 8, column: 9 }],
         },
       ]
+    );
+  });
+
+  it('get descriptions correctly with commentDescriptions option', () => {
+    expectPassesRuleWithConfiguration(
+      EnumValuesHaveDescriptions,
+      `
+      enum Status {
+        # Hidden
+        HIDDEN
+      }
+    `,
+      { commentDescriptions: true }
     );
   });
 });

--- a/test/rules/fields_have_descriptions.js
+++ b/test/rules/fields_have_descriptions.js
@@ -1,5 +1,8 @@
 import { FieldsHaveDescriptions } from '../../src/rules/fields_have_descriptions';
-import { expectFailsRule } from '../assertions';
+import {
+  expectFailsRule,
+  expectPassesRuleWithConfiguration,
+} from '../assertions';
 
 describe('FieldsHaveDescriptions rule', () => {
   it('catches fields that have no description', () => {
@@ -10,7 +13,7 @@ describe('FieldsHaveDescriptions rule', () => {
         withoutDescription: String
         withoutDescriptionAgain: String!
 
-        # Description
+        "Description"
         withDescription: String
       }
     `,
@@ -25,6 +28,19 @@ describe('FieldsHaveDescriptions rule', () => {
           locations: [{ line: 4, column: 9 }],
         },
       ]
+    );
+  });
+
+  it('gets descriptions correctly with commentDescriptions option', () => {
+    expectPassesRuleWithConfiguration(
+      FieldsHaveDescriptions,
+      `
+      type A {
+        "Description"
+        withDescription: String
+      }
+    `,
+      { commentDescriptions: true }
     );
   });
 });

--- a/test/rules/input_object_values_have_descriptions.js
+++ b/test/rules/input_object_values_have_descriptions.js
@@ -4,7 +4,11 @@ import { validate } from 'graphql/validation';
 import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 
 import { InputObjectValuesHaveDescriptions } from '../../src/rules/input_object_values_have_descriptions';
-import { expectFailsRule, expectPassesRule } from '../assertions';
+import {
+  expectFailsRule,
+  expectPassesRule,
+  expectPassesRuleWithConfiguration,
+} from '../assertions';
 
 describe('InputObjectValuesHaveDescriptions rule', () => {
   it('catches input object type values that have no description', () => {
@@ -14,7 +18,7 @@ describe('InputObjectValuesHaveDescriptions rule', () => {
       input User {
         username: String
 
-        # Description
+        "Description"
         withDescription: String
       }
     `,
@@ -35,6 +39,19 @@ describe('InputObjectValuesHaveDescriptions rule', () => {
         hello(argumentWithoutDescription: String): String
       }
     `
+    );
+  });
+
+  it('gets descriptions correctly with commentDescriptions option', () => {
+    expectPassesRuleWithConfiguration(
+      InputObjectValuesHaveDescriptions,
+      `
+      input F {
+        # F
+        f: String
+      }
+    `,
+      { commentDescriptions: true }
     );
   });
 });

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -1,12 +1,16 @@
 import { TypesHaveDescriptions } from '../../src/rules/types_have_descriptions';
-import { expectFailsRule, expectPassesRule } from '../assertions';
+import {
+  expectFailsRule,
+  expectPassesRule,
+  expectPassesRuleWithConfiguration,
+} from '../assertions';
 
 describe('TypesHaveDescriptions rule', () => {
   it('catches enum types that have no description', () => {
     expectFailsRule(
       TypesHaveDescriptions,
       `
-      # A
+      "A"
       enum A {
         A
       }
@@ -30,7 +34,7 @@ describe('TypesHaveDescriptions rule', () => {
     expectFailsRule(
       TypesHaveDescriptions,
       `
-      # A
+      "A"
       scalar A
 
       scalar DateTime
@@ -52,7 +56,7 @@ describe('TypesHaveDescriptions rule', () => {
         a: String
       }
 
-      # B
+      "B"
       type B {
         b: String
       }
@@ -74,7 +78,7 @@ describe('TypesHaveDescriptions rule', () => {
         id: ID!
       }
 
-      # RemoveStar
+      "RemoveStar"
       input RemoveStar {
         id: ID!
       }
@@ -92,7 +96,7 @@ describe('TypesHaveDescriptions rule', () => {
     expectFailsRule(
       TypesHaveDescriptions,
       `
-      # B
+      "B"
       interface B {
         B: String
       }
@@ -114,19 +118,19 @@ describe('TypesHaveDescriptions rule', () => {
     expectFailsRule(
       TypesHaveDescriptions,
       `
-      # A
+      "A"
       type A {
         a: String
       }
 
-      # B
+      "B"
       type B {
         b: String
       }
 
       union AB = A | B
 
-      # BA
+      "BA"
       union BA = B | A
     `,
       [
@@ -146,7 +150,7 @@ describe('TypesHaveDescriptions rule', () => {
         b: String
       }
 
-      # Interface
+      "Interface"
       interface Vehicle {
         make: String!
       }
@@ -155,6 +159,40 @@ describe('TypesHaveDescriptions rule', () => {
         something: String!
       }
     `
+    );
+  });
+
+  it('gets descriptions correctly with commentDescriptions option', () => {
+    expectPassesRuleWithConfiguration(
+      TypesHaveDescriptions,
+      `
+      # A
+      scalar A
+
+      # B
+      type B {
+        b: String
+      }
+
+      # C
+      interface C {
+        c: String
+      }
+
+      # D
+      union D = B
+
+      # E
+      enum E {
+        A
+      }
+
+      # F
+      input F {
+        f: String
+      }
+    `,
+      { commentDescriptions: true }
     );
   });
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -70,6 +70,27 @@ describe('Runner', () => {
       assert.equal(0, exitCode);
     });
 
+    it('allows setting descriptions using comments in GraphQL SDL', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'text',
+        '--comment-descriptions',
+        `${__dirname}/fixtures/schema.comment-descriptions.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      const expected =
+        `${__dirname}/fixtures/schema.comment-descriptions.graphql\n` +
+        '3:3 The field `Query.a` is missing a description.  fields-have-descriptions\n' +
+        '\n' +
+        '✖ 1 error detected\n';
+
+      assert.equal(expected, stripAnsi(stdout));
+    });
+
     it('validates a single schema file and outputs in text', () => {
       const argv = [
         'node',
@@ -108,7 +129,7 @@ describe('Runner', () => {
       const expected =
         `${__dirname}/fixtures/animal.graphql\n` +
         "18:3 The enum value `AnimalTypes.CAT_ENUM` cannot include the word 'enum'.  enum-name-cannot-contain-enum\n" +
-        "20:3 The enum value `AnimalTypes.DOG_ENUM` cannot include the word 'enum'.  enum-name-cannot-contain-enum\n" +
+        "21:3 The enum value `AnimalTypes.DOG_ENUM` cannot include the word 'enum'.  enum-name-cannot-contain-enum\n" +
         '\n' +
         '✖ 2 errors detected\n';
 

--- a/test/validator.js
+++ b/test/validator.js
@@ -12,7 +12,11 @@ describe('validateSchemaDefinition', () => {
     const schemaDefinition = configuration.getSchema();
     const rules = [FieldsHaveDescriptions, DummyValidator];
 
-    const errors = validateSchemaDefinition(schemaDefinition, rules);
+    const errors = validateSchemaDefinition(
+      schemaDefinition,
+      rules,
+      configuration
+    );
     const errorLineNumbers = errors.map(error => {
       return error.locations[0].line;
     });
@@ -28,9 +32,39 @@ describe('validateSchemaDefinition', () => {
 
     const schemaDefinition = configuration.getSchema();
 
-    const errors = validateSchemaDefinition(schemaDefinition, []);
+    const errors = validateSchemaDefinition(
+      schemaDefinition,
+      [],
+      configuration
+    );
 
     assert.equal(1, errors.length);
+  });
+
+  it('passes configuration to rules that require it', () => {
+    const schemaPath = `${__dirname}/fixtures/valid.graphql`;
+    const configuration = new Configuration({ schemaPaths: [schemaPath] });
+
+    const schemaDefinition = configuration.getSchema();
+
+    const ruleWithConfiguration = (config, context) => {
+      assert.equal(configuration, config);
+      assert.equal('ValidationContext', context.constructor.name);
+      return {};
+    };
+
+    const ruleWithoutConfiguration = context => {
+      assert.equal('ValidationContext', context.constructor.name);
+      return {};
+    };
+
+    const errors = validateSchemaDefinition(
+      schemaDefinition,
+      [ruleWithConfiguration, ruleWithoutConfiguration],
+      configuration
+    );
+
+    assert.equal(0, errors.length);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1466,11 +1466,17 @@ graphql-request@^1.2.0:
   dependencies:
     isomorphic-fetch "^2.2.1"
 
-"graphql@0.7.1 - 1.0.0", graphql@^0.10.1:
+"graphql@0.7.1 - 1.0.0":
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
   dependencies:
     iterall "^1.1.0"
+
+graphql@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.0.tgz#d1b44a282279a9ce0a6ec1037329332f4c1079b6"
+  dependencies:
+    iterall "1.1.x"
 
 growl@1.9.2:
   version "1.9.2"
@@ -1745,6 +1751,10 @@ isomorphic-fetch@^2.2.1:
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+
+iterall@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.4.tgz#0db40d38fdcf53ae14dc8ec674e62ab190d52cfc"
 
 iterall@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Fixes #77 

As per https://github.com/graphql/graphql-js/pull/927, descriptions are now strings instead of comments in the SDL.

For example:

**Before**

```graphql
# Query
type Query {
  # A
  a: String
}
```

**Now**

```graphql
"Query"
type Query {
  "A"
  a: String
}
```

Moving forward schemas will need to use this syntax. **In order to provide a graceful upgrade path,** users can use the `--comment-descriptions` CLI option to use the old way of defining descriptions for types.