### PR TITLE
Allow non-null list for `edges` field

### DIFF
--- a/src/rules/relay_connection_types_spec.js
+++ b/src/rules/relay_connection_types_spec.js
@@ -48,7 +48,11 @@ export function RelayConnectionTypesSpec(context) {
       }
 
       const edgesField = node.fields.find(field => field.name.value == 'edges');
-      const edgesFieldType = edgesField.type;
+      var edgesFieldType = edgesField.type;
+
+      if (edgesFieldType.kind == 'NonNullType') {
+        edgesFieldType = edgesFieldType.type;
+      }
 
       if (edgesFieldType.kind != 'ListType') {
         context.reportError(

--- a/test/rules/relay_connection_types_spec.js
+++ b/test/rules/relay_connection_types_spec.js
@@ -36,6 +36,21 @@ describe('RelayConnectionTypesSpec  rule', () => {
         pageInfo: PageInfo!
         edges: [Edge]
       }
+
+      type AnotherConnection {
+        pageInfo: PageInfo!
+        edges: [Edge]!
+      }
+
+      type AnotherGoodConnection {
+        pageInfo: PageInfo!
+        edges: [Edge!]!
+      }
+
+      type AgainAnotherConnection {
+        pageInfo: PageInfo!
+        edges: [Edge!]
+      }
     `
     );
   });


### PR DESCRIPTION
Fixes #108

Previously the `relay-connection-types-spec` rule would reject non-null list `edges` field.

I can't think of any reason why we should prevent this. It's also unclear in the specification whether non-null lists are acceptable.