### PR TITLE
Add `relay-page-info-spec` rule

### DIFF
--- a/src/rules/relay_page_info_spec.js
+++ b/src/rules/relay_page_info_spec.js
@@ -1,0 +1,64 @@
+import { ValidationError } from '../validation_error';
+import { print } from 'graphql/language/printer';
+
+export function RelayPageInfoSpec(context) {
+  return {
+    Document: {
+      leave: function(node) {
+        const pageInfoType = context.getSchema().getType('PageInfo');
+
+        if (!pageInfoType) {
+          return context.reportError(
+            new ValidationError(
+              'relay-page-info-spec',
+              'A `PageInfo` object type is required as per the Relay spec.',
+              [node]
+            )
+          );
+        }
+
+        const pageInfoFields = pageInfoType.getFields();
+
+        const hasPreviousPageField = pageInfoFields['hasPreviousPage'];
+
+        if (!hasPreviousPageField) {
+          context.reportError(
+            new ValidationError(
+              'relay-page-info-spec',
+              'The `PageInfo` object type must have a `hasPreviousPage` field that returns a non-null Boolean as per the Relay spec.',
+              [pageInfoType.astNode]
+            )
+          );
+        } else if (hasPreviousPageField.type != 'Boolean!') {
+          context.reportError(
+            new ValidationError(
+              'relay-page-info-spec',
+              'The `PageInfo` object type must have a `hasPreviousPage` field that returns a non-null Boolean as per the Relay spec.',
+              [hasPreviousPageField.astNode]
+            )
+          );
+        }
+
+        const hasNextPageField = pageInfoFields['hasNextPage'];
+
+        if (!hasNextPageField) {
+          context.reportError(
+            new ValidationError(
+              'relay-page-info-spec',
+              'The `PageInfo` object type must have a `hasNextPage` field that returns a non-null Boolean as per the Relay spec.',
+              [pageInfoType.astNode]
+            )
+          );
+        } else if (hasNextPageField.type != 'Boolean!') {
+          context.reportError(
+            new ValidationError(
+              'relay-page-info-spec',
+              'The `PageInfo` object type must have a `hasNextPage` field that returns a non-null Boolean as per the Relay spec.',
+              [hasNextPageField.astNode]
+            )
+          );
+        }
+      },
+    },
+  };
+}

--- a/test/fixtures/valid.graphql
+++ b/test/fixtures/valid.graphql
@@ -2,4 +2,16 @@
 type Query {
   "a"
   a: String!
+
+  "something"
+  something: PageInfo!
+}
+
+"PageInfo"
+type PageInfo {
+  "hasNextPage"
+  hasNextPage: Boolean!
+
+  "hasPreviousPage"
+  hasPreviousPage: Boolean!
 }

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,7 @@ require('./rules/input_object_values_have_descriptions');
 require('./rules/input_object_values_are_camel_cased');
 require('./rules/enum_values_have_descriptions');
 require('./rules/relay_connection_types_spec');
+require('./rules/relay_page_info_spec');
 require('./formatters/json_formatter');
 require('./formatters/text_formatter');
 require('./config/rc_file/test');

--- a/test/rules/relay_page_info_spec.js
+++ b/test/rules/relay_page_info_spec.js
@@ -1,0 +1,124 @@
+import { RelayPageInfoSpec } from '../../src/rules/relay_page_info_spec';
+import { expectFailsRule, expectPassesRule } from '../assertions';
+
+describe('RelayPageInfoSpec  rule', () => {
+  it('catches missing PageInfo type', () => {
+    expectFailsRule(RelayPageInfoSpec, '', [
+      {
+        locations: [
+          {
+            column: 1,
+            line: 1,
+          },
+        ],
+        message: 'A `PageInfo` object type is required as per the Relay spec.',
+      },
+    ]);
+  });
+
+  it('catches missing PageInfo.hasPreviousPage field', () => {
+    expectFailsRule(
+      RelayPageInfoSpec,
+      `
+      type PageInfo {
+        hasNextPage: Boolean!
+      }
+      `,
+      [
+        {
+          locations: [
+            {
+              column: 7,
+              line: 2,
+            },
+          ],
+          message:
+            'The `PageInfo` object type must have a `hasPreviousPage` field that returns a non-null Boolean as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
+  it('catches invalid PageInfo.hasPreviousPage field', () => {
+    expectFailsRule(
+      RelayPageInfoSpec,
+      `
+      type PageInfo {
+        hasNextPage: Boolean!
+        hasPreviousPage: String!
+      }
+      `,
+      [
+        {
+          locations: [
+            {
+              column: 9,
+              line: 4,
+            },
+          ],
+          message:
+            'The `PageInfo` object type must have a `hasPreviousPage` field that returns a non-null Boolean as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
+  it('catches missing PageInfo.hasNextPage field', () => {
+    expectFailsRule(
+      RelayPageInfoSpec,
+      `
+      type PageInfo {
+        hasPreviousPage: Boolean!
+      }
+      `,
+      [
+        {
+          locations: [
+            {
+              column: 7,
+              line: 2,
+            },
+          ],
+          message:
+            'The `PageInfo` object type must have a `hasNextPage` field that returns a non-null Boolean as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
+  it('catches invalid PageInfo.hasNextPage field', () => {
+    expectFailsRule(
+      RelayPageInfoSpec,
+      `
+      type PageInfo {
+        hasNextPage: String!
+        hasPreviousPage: Boolean!
+      }
+      `,
+      [
+        {
+          locations: [
+            {
+              column: 9,
+              line: 3,
+            },
+          ],
+          message:
+            'The `PageInfo` object type must have a `hasNextPage` field that returns a non-null Boolean as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
+  it('accepts proper definition', () => {
+    expectPassesRule(
+      RelayPageInfoSpec,
+      `
+      type PageInfo {
+        hasNextPage: Boolean!
+        hasPreviousPage: Boolean!
+      }
+    `
+    );
+  });
+});

--- a/test/runner.js
+++ b/test/runner.js
@@ -77,6 +77,8 @@ describe('Runner', () => {
         '--format',
         'text',
         '--comment-descriptions',
+        '--rules',
+        'fields-have-descriptions',
         `${__dirname}/fixtures/schema.comment-descriptions.graphql`,
       ];
 
@@ -119,6 +121,8 @@ describe('Runner', () => {
         'lib/cli.js',
         '--format',
         'text',
+        '--rules',
+        'enum-name-cannot-contain-enum',
         '--custom-rule-paths',
         `${__dirname}/fixtures/custom_rules/*`,
         `${__dirname}/fixtures/animal.graphql`,


### PR DESCRIPTION
This rule covers section 5 of the Relay spec: https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo