### PR TITLE
 Add `relay-connection-arguments-spec` rule

### DIFF
--- a/src/rules/relay_connection_arguments_spec.js
+++ b/src/rules/relay_connection_arguments_spec.js
@@ -1,0 +1,79 @@
+import { ValidationError } from '../validation_error';
+
+function unwrapType(type) {
+  if (type.kind == 'NonNullType') {
+    return type.type;
+  } else {
+    return type;
+  }
+}
+
+export function RelayConnectionArgumentsSpec(context) {
+  return {
+    FieldDefinition(node) {
+      const fieldType = unwrapType(node.type);
+      if (
+        fieldType.kind != 'NamedType' ||
+        !fieldType.name.value.endsWith('Connection')
+      ) {
+        return;
+      }
+
+      const firstArgument = node.arguments.find(argument => {
+        return argument.name.value == 'first';
+      });
+      const afterArgument = node.arguments.find(argument => {
+        return argument.name.value == 'after';
+      });
+      const hasForwardPagination = firstArgument && afterArgument;
+
+      const lastArgument = node.arguments.find(argument => {
+        return argument.name.value == 'last';
+      });
+      const beforeArgument = node.arguments.find(argument => {
+        return argument.name.value == 'before';
+      });
+      const hasBackwardPagination = lastArgument && beforeArgument;
+
+      if (!hasForwardPagination && !hasBackwardPagination) {
+        return context.reportError(
+          new ValidationError(
+            'relay-connection-arguments-spec',
+            'A field that returns a Connection Type must include forward pagination arguments (`first` and `after`), backward pagination arguments (`last` and `before`), or both as per the Relay spec.',
+            [node]
+          )
+        );
+      }
+
+      if (firstArgument) {
+        if (
+          firstArgument.type.kind != 'NamedType' ||
+          firstArgument.type.name.value != 'Int'
+        ) {
+          return context.reportError(
+            new ValidationError(
+              'relay-connection-arguments-spec',
+              'Fields that support forward pagination must include a `first` argument that takes a non-negative integer as per the Relay spec.',
+              [firstArgument]
+            )
+          );
+        }
+      }
+
+      if (lastArgument) {
+        if (
+          lastArgument.type.kind != 'NamedType' ||
+          lastArgument.type.name.value != 'Int'
+        ) {
+          return context.reportError(
+            new ValidationError(
+              'relay-connection-arguments-spec',
+              'Fields that support forward pagination must include a `last` argument that takes a non-negative integer as per the Relay spec.',
+              [lastArgument]
+            )
+          );
+        }
+      }
+    },
+  };
+}

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,7 @@ require('./rules/input_object_values_have_descriptions');
 require('./rules/input_object_values_are_camel_cased');
 require('./rules/enum_values_have_descriptions');
 require('./rules/relay_connection_types_spec');
+require('./rules/relay_connection_arguments_spec');
 require('./rules/relay_page_info_spec');
 require('./formatters/json_formatter');
 require('./formatters/text_formatter');

--- a/test/rules/relay_connection_arguments_spec.js
+++ b/test/rules/relay_connection_arguments_spec.js
@@ -1,0 +1,130 @@
+import { RelayConnectionArgumentsSpec } from '../../src/rules/relay_connection_arguments_spec';
+import { expectFailsRule, expectPassesRule } from '../assertions';
+
+describe('RelayConnectionArgumentsSpec rule', () => {
+  it('reports connections that do not support forward or backward pagination', () => {
+    expectFailsRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users: UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `,
+      [
+        {
+          locations: [
+            {
+              column: 9,
+              line: 3,
+            },
+          ],
+          message:
+            'A field that returns a Connection Type must include forward pagination arguments (`first` and `after`), backward pagination arguments (`last` and `before`), or both as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
+  it('accepts connection with proper forward pagination arguments', () => {
+    expectPassesRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(first: Int, after: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `
+    );
+  });
+
+  it('accepts connection with proper backward pagination arguments', () => {
+    expectPassesRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(last: Int, before: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `
+    );
+  });
+
+  it('accepts connection with proper foward and backward pagination arguments', () => {
+    expectPassesRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(first: Int, after: String, last: Int, before: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `
+    );
+  });
+
+  it('reports invalid first argument', () => {
+    expectFailsRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(first: String, after: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `,
+      [
+        {
+          locations: [
+            {
+              column: 15,
+              line: 3,
+            },
+          ],
+          message:
+            'Fields that support forward pagination must include a `first` argument that takes a non-negative integer as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
+  it('reports invalid last argument', () => {
+    expectFailsRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(last: String, before: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `,
+      [
+        {
+          locations: [
+            {
+              column: 15,
+              line: 3,
+            },
+          ],
+          message:
+            'Fields that support forward pagination must include a `last` argument that takes a non-negative integer as per the Relay spec.',
+        },
+      ]
+    );
+  });
+});

--- a/test/rules/relay_connection_types_spec.js
+++ b/test/rules/relay_connection_types_spec.js
@@ -1,7 +1,7 @@
 import { RelayConnectionTypesSpec } from '../../src/rules/relay_connection_types_spec';
 import { expectFailsRule, expectPassesRule } from '../assertions';
 
-describe('RelayConnectionTypesSpec  rule', () => {
+describe('RelayConnectionTypesSpec rule', () => {
   it('catches object types that have missing fields', () => {
     expectFailsRule(
       RelayConnectionTypesSpec,


### PR DESCRIPTION
Fixes #114 

Add a new rule called `relay-connection-arguments-spec` that covers: https://facebook.github.io/relay/graphql/connections.htm#sec-Arguments