### PR TITLE
Add `--old-implements-syntax` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,6 @@ Options:
 
     schema definition will be read from STDIN instead of specified file
 
-  --comment-descriptions
-
-    use old way of defining descriptions in GraphQL SDL
-
   -c, --config-direction <path>
 
     path to begin searching for config files
@@ -55,6 +51,14 @@ Options:
   -p, --custom-rule-paths <paths>
 
     path to additional custom rules to be loaded. Example: rules/*.js
+
+  --comment-descriptions
+
+    use old way of defining descriptions in GraphQL SDL
+
+  --old-implements-syntax
+
+    use old way of defining implemented interfaces in GraphQL SDL
 
   --version
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -17,12 +17,14 @@ export class Configuration {
       - customRulePaths: [string array] path to additional custom rules to be loaded
       - stdin: [boolean] pass schema via stdin?
       - commentDescriptions: [boolean] use old way of defining descriptions in GraphQL SDL
+      - oldImplementsSyntax: [boolean] use old way of defining implemented interfaces in GraphQL SDL
   */
   constructor(options = {}, stdinFd = null) {
     const defaultOptions = {
       format: 'text',
       customRulePaths: [],
       commentDescriptions: false,
+      oldImplementsSyntax: false,
     };
     const configOptions = loadOptionsFromConfig(options.configDirectory);
 
@@ -40,6 +42,10 @@ export class Configuration {
 
   getCommentDescriptions() {
     return this.options.commentDescriptions;
+  }
+
+  getOldImplementsSyntax() {
+    return this.options.oldImplementsSyntax;
   }
 
   getSchema() {

--- a/src/runner.js
+++ b/src/runner.js
@@ -32,6 +32,10 @@ export function run(stdout, stdin, stderr, argv) {
       '--comment-descriptions',
       'use old way of defining descriptions in GraphQL SDL'
     )
+    .option(
+      '--old-implements-syntax',
+      'use old way of defining implemented interfaces in GraphQL SDL'
+    )
     // DEPRECATED - This code should be removed in v1.0.0.
     .option(
       '-o, --only <rules>',
@@ -142,6 +146,10 @@ function getOptionsFromCommander(commander) {
 
   if (commander.commentDescriptions) {
     options.commentDescriptions = commander.commentDescriptions;
+  }
+
+  if (commander.oldImplementsSyntax) {
+    options.oldImplementsSyntax = commander.oldImplementsSyntax;
   }
 
   if (commander.args && commander.args.length) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -9,8 +9,14 @@ export function validateSchemaDefinition(
   configuration
 ) {
   let ast;
+
+  let parseOptions = {};
+  if (configuration.getOldImplementsSyntax()) {
+    parseOptions.allowLegacySDLImplementsInterfaces = true;
+  }
+
   try {
-    ast = parse(schemaDefinition);
+    ast = parse(schemaDefinition, parseOptions);
   } catch (e) {
     if (e instanceof GraphQLError) {
       return [e];

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -274,4 +274,16 @@ extend type Query {
       assert.equal(configuration.getCommentDescriptions(), true);
     });
   });
+
+  describe('getOldImplementsSyntax', () => {
+    it('defaults to false', () => {
+      const configuration = new Configuration({});
+      assert.equal(configuration.getOldImplementsSyntax(), false);
+    });
+
+    it('returns specified value', () => {
+      const configuration = new Configuration({ oldImplementsSyntax: true });
+      assert.equal(configuration.getOldImplementsSyntax(), true);
+    });
+  });
 });

--- a/test/fixtures/schema.new-implements.graphql
+++ b/test/fixtures/schema.new-implements.graphql
@@ -1,0 +1,29 @@
+"""
+Query
+"""
+type Query {
+  node(id: ID!): Node
+  posts: [Post!]!
+}
+
+"""
+Post
+"""
+type Post implements Node & Commentable {
+  id: ID!
+  comments: [String!]!
+}
+
+"""
+Node
+"""
+interface Node {
+  id: ID!
+}
+
+"""
+Commentable
+"""
+interface Commentable {
+  comments: [String!]!
+}

--- a/test/fixtures/schema.old-implements.graphql
+++ b/test/fixtures/schema.old-implements.graphql
@@ -1,0 +1,29 @@
+"""
+Query
+"""
+type Query {
+  node(id: ID!): Node
+  posts: [Post!]!
+}
+
+"""
+Post
+"""
+type Post implements Node, Commentable {
+  id: ID!
+  comments: [String!]!
+}
+
+"""
+Node
+"""
+interface Node {
+  id: ID!
+}
+
+"""
+Commentable
+"""
+interface Commentable {
+  comments: [String!]!
+}

--- a/test/runner.js
+++ b/test/runner.js
@@ -93,6 +93,39 @@ describe('Runner', () => {
       assert.equal(expected, stripAnsi(stdout));
     });
 
+    it('allows using old `implements` syntax in GraphQL SDL', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'json',
+        '--old-implements-syntax',
+        '--rules',
+        'types-have-descriptions',
+        `${__dirname}/fixtures/schema.old-implements.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      assert.deepEqual([], JSON.parse(stdout)['errors']);
+    });
+
+    it('validates using new `implements` syntax in GraphQL SDL', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--format',
+        'json',
+        '--rules',
+        'types-have-descriptions',
+        `${__dirname}/fixtures/schema.new-implements.graphql`,
+      ];
+
+      run(mockStdout, mockStdin, mockStderr, argv);
+
+      assert.deepEqual([], JSON.parse(stdout)['errors']);
+    });
+
     it('validates a single schema file and outputs in text', () => {
       const argv = [
         'node',


### PR DESCRIPTION
Closes #111 

As of [`v0.13.0` of GraphQL.js](https://github.com/graphql/graphql-js/releases/tag/v0.13.0) the syntax for implementing multiple interfaces [has slightly changed](https://github.com/graphql/graphql-js/pull/1169).

Previously you could separate each interface with a blank space or comma:

```graphql
type Foo implements Bar, Baz { field: Type }
```

But the new syntax is to separate using `&`:

```graphql
type Foo implements Bar & Baz { field: Type }
```

This pull request adds `--old-implements-syntax` in order to support schemas that still use the old way.

This option will be removed when GraphQL.js drops support for the old way.