### PR TITLE
Dedup rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "test": "mocha test/index.js",
-    "prepare": "babel ./src --ignore test --out-dir ./lib"
+    "prepare": "rm -rf lib/* && babel ./src --ignore test --out-dir ./lib"
   },
   "homepage": "https://github.com/cjoudrey/graphql-schema-linter",
   "repository": {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -125,15 +125,14 @@ export class Configuration {
     }
 
     let expandedPaths = expandPaths(this.rulePaths);
-    this.rules = [];
+    let rules = new Set([]);
+
     expandedPaths.map(rulePath => {
       let ruleMap = require(rulePath);
-      let rule = Object.keys(ruleMap).map(k => ruleMap[k]);
-
-      if (rule) {
-        this.rules = this.rules.concat(rule);
-      }
+      Object.keys(ruleMap).forEach(k => rules.add(ruleMap[k]));
     });
+
+    this.rules = Array.from(rules);
 
     return this.rules;
   }

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -185,9 +185,12 @@ extend type Query {
       );
     });
 
-    it('adds custom rules that are specified in --custom-rules-path', () => {
+    it('dedups duplicate rules', () => {
       const configuration = new Configuration({
-        customRulePaths: [`${__dirname}/fixtures/custom_rules/*.js`],
+        customRulePaths: [
+          `${__dirname}/fixtures/custom_rules/*.js`,
+          `${__dirname}/fixtures/custom_rules/type_name_cannot_contain_type.js`,
+        ],
       });
 
       const rules = configuration.getRules();
@@ -196,6 +199,26 @@ extend type Query {
         2,
         rules.filter(rule => {
           return (
+            rule.name == 'EnumNameCannotContainEnum' ||
+            rule.name == 'TypeNameCannotContainType'
+          );
+        }).length
+      );
+    });
+
+    it('adds custom rules that are specified in --custom-rules-path', () => {
+      const configuration = new Configuration({
+        customRulePaths: [`${__dirname}/fixtures/custom_rules/*.js`],
+      });
+
+      const rules = configuration.getRules();
+
+      assert.equal(
+        4,
+        rules.filter(rule => {
+          return (
+            rule.name == 'SomeRule' ||
+            rule.name == 'AnotherRule' ||
             rule.name == 'EnumNameCannotContainEnum' ||
             rule.name == 'TypeNameCannotContainType'
           );

--- a/test/fixtures/custom_rules/many_rules.js
+++ b/test/fixtures/custom_rules/many_rules.js
@@ -1,0 +1,11 @@
+export function SomeRule(context) {
+  return {
+    EnumValueDefinition(node, key, parent, path, ancestors) {},
+  };
+}
+
+export function AnotherRule(context) {
+  return {
+    EnumValueDefinition(node, key, parent, path, ancestors) {},
+  };
+}


### PR DESCRIPTION
Fixes #132 

For some reason a `rules/index.js` found its way into `lib/` which caused all rules to be loaded twice.

I've since removed the file and it doesn't seem to re-appear when running `yarn prepare`. Very strange.

This PR uses a `Set` to dedup rules in case this happens again or if someone tries to load the same rules file twice.