### PR TITLE
allow interfaces to end with Connection

### DIFF
--- a/src/rules/relay_connection_types_spec.js
+++ b/src/rules/relay_connection_types_spec.js
@@ -2,15 +2,75 @@ import { ValidationError } from '../validation_error';
 import { print } from 'graphql/language/printer';
 
 const MANDATORY_FIELDS = ['pageInfo', 'edges'];
+const RULE_NAME = 'relay-connection-types-spec';
 
 export function RelayConnectionTypesSpec(context) {
-  var ensureNameDoesNotEndWithConnection = node => {
+  const ensureNameDoesNotEndWithConnection = node => {
     if (node.name.value.match(/Connection$/)) {
       context.reportError(
         new ValidationError(
-          'relay-connection-types-spec',
-          `Types that end in \`Connection\` must be an object type as per the relay spec. \`${node
-            .name.value}\` is not an object type.`,
+          RULE_NAME,
+          `Types that end in \`Connection\` must be an object type as per the relay spec. \`${
+            node.name.value
+          }\` is not an object type.`,
+          [node]
+        )
+      );
+    }
+  };
+
+  const ensureValidObjectOrInterface = node => {
+    const typeName = node.name.value;
+    if (!typeName.endsWith('Connection')) {
+      return;
+    }
+    const fieldNames = node.fields.map(field => field.name.value);
+    const missingFields = MANDATORY_FIELDS.filter(
+      requiredField => fieldNames.indexOf(requiredField) === -1
+    );
+
+    if (missingFields.length) {
+      context.reportError(
+        new ValidationError(
+          RULE_NAME,
+          `Connection \`${typeName}\` is missing the following field${
+            missingFields.length > 1 ? 's' : ''
+          }: ${missingFields.join(', ')}.`,
+          [node]
+        )
+      );
+      return;
+    }
+
+    const edgesField = node.fields.find(field => field.name.value == 'edges');
+    let edgesFieldType = edgesField.type;
+
+    if (edgesFieldType.kind == 'NonNullType') {
+      edgesFieldType = edgesFieldType.type;
+    }
+
+    if (edgesFieldType.kind != 'ListType') {
+      context.reportError(
+        new ValidationError(
+          RULE_NAME,
+          `The \`${typeName}.edges\` field must return a list of edges not \`${print(
+            edgesFieldType
+          )}\`.`,
+          [node]
+        )
+      );
+    }
+
+    const pageInfoField = node.fields.find(
+      field => field.name.value == 'pageInfo'
+    );
+    const printedPageInfoFieldType = print(pageInfoField.type);
+
+    if (printedPageInfoFieldType != 'PageInfo!') {
+      context.reportError(
+        new ValidationError(
+          RULE_NAME,
+          `The \`${typeName}.pageInfo\` field must return a non-null \`PageInfo\` object not \`${printedPageInfoFieldType}\``,
           [node]
         )
       );
@@ -19,67 +79,10 @@ export function RelayConnectionTypesSpec(context) {
 
   return {
     ScalarTypeDefinition: ensureNameDoesNotEndWithConnection,
-    InterfaceTypeDefinition: ensureNameDoesNotEndWithConnection,
+    InterfaceTypeDefinition: ensureValidObjectOrInterface,
     UnionTypeDefinition: ensureNameDoesNotEndWithConnection,
     EnumTypeDefinition: ensureNameDoesNotEndWithConnection,
     InputObjectTypeDefinition: ensureNameDoesNotEndWithConnection,
-    ObjectTypeDefinition(node) {
-      const typeName = node.name.value;
-      if (!typeName.endsWith('Connection')) {
-        return;
-      }
-      const fieldNames = node.fields.map(field => field.name.value);
-      const missingFields = MANDATORY_FIELDS.filter(
-        requiredField => fieldNames.indexOf(requiredField) === -1
-      );
-
-      if (missingFields.length) {
-        context.reportError(
-          new ValidationError(
-            'relay-connection-types-spec',
-            `Connection \`${typeName}\` is missing the following field${missingFields.length >
-            1
-              ? 's'
-              : ''}: ${missingFields.join(', ')}.`,
-            [node]
-          )
-        );
-        return;
-      }
-
-      const edgesField = node.fields.find(field => field.name.value == 'edges');
-      var edgesFieldType = edgesField.type;
-
-      if (edgesFieldType.kind == 'NonNullType') {
-        edgesFieldType = edgesFieldType.type;
-      }
-
-      if (edgesFieldType.kind != 'ListType') {
-        context.reportError(
-          new ValidationError(
-            'relay-connection-types-spec',
-            `The \`${typeName}.edges\` field must return a list of edges not \`${print(
-              edgesFieldType
-            )}\`.`,
-            [node]
-          )
-        );
-      }
-
-      const pageInfoField = node.fields.find(
-        field => field.name.value == 'pageInfo'
-      );
-      const printedPageInfoFieldType = print(pageInfoField.type);
-
-      if (printedPageInfoFieldType != 'PageInfo!') {
-        context.reportError(
-          new ValidationError(
-            'relay-connection-types-spec',
-            `The \`${typeName}.pageInfo\` field must return a non-null \`PageInfo\` object not \`${printedPageInfoFieldType}\``,
-            [node]
-          )
-        );
-      }
-    },
+    ObjectTypeDefinition: ensureValidObjectOrInterface,
   };
 }

--- a/test/rules/relay_connection_types_spec.js
+++ b/test/rules/relay_connection_types_spec.js
@@ -55,6 +55,31 @@ describe('RelayConnectionTypesSpec rule', () => {
     );
   });
 
+  it('accepts interfaces with the correct fields.', () => {
+    expectPassesRule(
+      RelayConnectionTypesSpec,
+      `
+      type PageInfo {
+        a: String
+      }
+
+      interface Edge {
+        a: String
+      }
+
+      interface Connection {
+        pageInfo: PageInfo!
+        edges: [Edge!]!
+      }
+
+      interface OtherConnection {
+        pageInfo: PageInfo!
+        edges: [Edge!]!
+      }
+    `
+    );
+  });
+
   it('catches edges fields that are not lists of edges', () => {
     expectFailsRule(
       RelayConnectionTypesSpec,
@@ -145,10 +170,6 @@ describe('RelayConnectionTypesSpec rule', () => {
       `
       scalar AConnection
 
-      interface BConnection {
-        a: String!
-      }
-
       type F {
         a: String!
       }
@@ -179,19 +200,7 @@ describe('RelayConnectionTypesSpec rule', () => {
           locations: [
             {
               column: 7,
-              line: 4,
-            },
-          ],
-          message:
-            'Types that end in `Connection` must be an object type as per the relay spec. `BConnection` is not an object type.',
-          path: [undefined],
-          ruleName: 'relay-connection-types-spec',
-        },
-        {
-          locations: [
-            {
-              column: 7,
-              line: 11,
+              line: 7,
             },
           ],
           message:
@@ -203,7 +212,7 @@ describe('RelayConnectionTypesSpec rule', () => {
           locations: [
             {
               column: 7,
-              line: 13,
+              line: 9,
             },
           ],
           message:
@@ -215,7 +224,7 @@ describe('RelayConnectionTypesSpec rule', () => {
           locations: [
             {
               column: 7,
-              line: 17,
+              line: 13,
             },
           ],
           message:


### PR DESCRIPTION
By implementing `interface Connection` in a GraphQL schema, clients can feel safe knowing that types that implement `Connection` are following the relay spec.

Adds support for interfaces to be named `Connection` or end with `Connection` (e.g. `interface MyConnection`). Now the linter can ensure `interface`s follow the relay spec and GraphQL libs can assert that types that implement said `interfaces` are properly implemented

## Related issue
https://github.com/cjoudrey/graphql-schema-linter/issues/138