### PR TITLE
Handle invalid schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "cosmiconfig": "^4.0.0",
     "figures": "^2.0.0",
     "glob": "^7.1.2",
-    "graphql": "^14.0.2",
+    "graphql": "^14.0.0",
     "lodash": "^4.17.4"
   },
   "bin": {

--- a/src/validator.js
+++ b/src/validator.js
@@ -21,6 +21,8 @@ export function validateSchemaDefinition(
     ast = parse(schemaDefinition, parseOptions);
   } catch (e) {
     if (e instanceof GraphQLError) {
+      e.ruleName = 'graphql-syntax-error';
+
       return [e];
     } else {
       throw e;
@@ -29,7 +31,13 @@ export function validateSchemaDefinition(
 
   let schemaErrors = validateSDL(ast);
   if (schemaErrors.length > 0) {
-    return sortErrors(schemaErrors);
+    return sortErrors(
+      schemaErrors.map(error => {
+        error.ruleName = 'invalid-graphql-schema';
+
+        return error;
+      })
+    );
   }
 
   const schema = buildASTSchema(ast, {
@@ -41,7 +49,13 @@ export function validateSchemaDefinition(
   schema.__validationErrors = undefined;
   schemaErrors = validateSchema(schema);
   if (schemaErrors.length > 0) {
-    return sortErrors(schemaErrors);
+    return sortErrors(
+      schemaErrors.map(error => {
+        error.ruleName = 'invalid-graphql-schema';
+
+        return error;
+      })
+    );
   }
 
   const rulesWithConfiguration = rules.map(rule => {

--- a/test/fixtures/invalid-query-root.graphql
+++ b/test/fixtures/invalid-query-root.graphql
@@ -1,0 +1,3 @@
+interface Query {
+  a: String
+}

--- a/test/fixtures/invalid-schema.graphql
+++ b/test/fixtures/invalid-schema.graphql
@@ -1,0 +1,8 @@
+type Query {
+  a: String
+  b: Node
+}
+
+type Another {
+  b: Product
+}

--- a/test/rules/defined_types_are_used.js
+++ b/test/rules/defined_types_are_used.js
@@ -132,7 +132,7 @@ describe('DefinedTypesAreUsed rule', () => {
       DefinedTypesAreUsed,
       `
       extend type Query {
-        a: Node
+        c: Node
       }
 
       interface Node {
@@ -206,7 +206,7 @@ describe('DefinedTypesAreUsed rule', () => {
       DefinedTypesAreUsed,
       `
       extend type Query {
-        a: String
+        c: String
       }
     `
     );

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -155,7 +155,7 @@ describe('TypesHaveDescriptions rule', () => {
         make: String!
       }
 
-      extend type Vehicle {
+      extend interface Vehicle {
         something: String!
       }
     `

--- a/test/validator.js
+++ b/test/validator.js
@@ -41,6 +41,48 @@ describe('validateSchemaDefinition', () => {
     assert.equal(1, errors.length);
   });
 
+  it('catches and returns GraphQL schema errors', () => {
+    const schemaPath = `${__dirname}/fixtures/invalid-schema.graphql`;
+    const configuration = new Configuration({ schemaPaths: [schemaPath] });
+
+    const schemaDefinition = configuration.getSchema();
+
+    const errors = validateSchemaDefinition(
+      schemaDefinition,
+      [],
+      configuration
+    );
+
+    assert.equal(2, errors.length);
+
+    assert.equal('Unknown type "Node".', errors[0].message);
+    assert.equal(3, errors[0].locations[0].line);
+
+    assert.equal('Unknown type "Product".', errors[1].message);
+    assert.equal(7, errors[1].locations[0].line);
+  });
+
+  it('handles invalid GraphQL schemas', () => {
+    const schemaPath = `${__dirname}/fixtures/invalid-query-root.graphql`;
+    const configuration = new Configuration({ schemaPaths: [schemaPath] });
+
+    const schemaDefinition = configuration.getSchema();
+
+    const errors = validateSchemaDefinition(
+      schemaDefinition,
+      [],
+      configuration
+    );
+
+    assert.equal(1, errors.length);
+
+    assert.equal(
+      'Query root type must be Object type, it cannot be Query.',
+      errors[0].message
+    );
+    assert.equal(1, errors[0].locations[0].line);
+  });
+
   it('passes configuration to rules that require it', () => {
     const schemaPath = `${__dirname}/fixtures/valid.graphql`;
     const configuration = new Configuration({ schemaPaths: [schemaPath] });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1614,10 +1614,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-graphql@^14.0.2:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.0.2.tgz#7dded337a4c3fd2d075692323384034b357f5650"
-  integrity sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==
+graphql@^14.0.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.1.0.tgz#f38eb11bf9b4678a9a7741de795a3d25d46a7490"
+  integrity sha512-1dFYdyjS3A2BmoYXXwmpNIr2SoSpcPkF6gXB4UqZh2mWKBLfyUaQbk2POigqrKvlCimphJoPgkb0SFxDgJwSXQ==
   dependencies:
     iterall "^1.2.2"
 


### PR DESCRIPTION
Fixes #53 #70 #136 #154 #157 #160 #162 

Previously, when linting an invalid GraphQL schema (i.e. referencing an undefined type), the linter would crash and output an unhelpful error message:

```
It looks like you may have hit a bug in graphql-schema-linter.

It would be super helpful if you could report this here: https://github.com/cjoudrey/graphql-schema-linter/issues/new

Error: Unknown type "Foo".
```

Thanks to some work by `@IvanGoncharov` in GraphQL.js, we can now correctly handle these errors:

```
schema.graphql
6:8 Unknown type "Foo".  invalid-graphql-schema

✖ 1 error detected
```

This pull request enables two new rules that will always run: `invalid-graphql-schema` and `graphql-syntax-error`.