### PR TITLE
Remove dependency on `figures` and `lodash`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "commander": "^2.11.0",
     "cosmiconfig": "^4.0.0",
     "glob": "^7.1.2",
-    "graphql": "^14.0.0",
-    "lodash": "^4.17.4"
+    "graphql": "^14.0.0"
   },
   "bin": {
     "graphql-schema-linter": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "columnify": "^1.5.4",
     "commander": "^2.11.0",
     "cosmiconfig": "^4.0.0",
-    "figures": "^2.0.0",
     "glob": "^7.1.2",
     "graphql": "^14.0.0",
     "lodash": "^4.17.4"

--- a/src/figures.js
+++ b/src/figures.js
@@ -1,0 +1,17 @@
+const { platform } = process;
+
+const main = {
+  tick: '✔',
+  cross: '✖',
+  warning: '⚠',
+};
+
+const windows = {
+  tick: '√',
+  cross: '×',
+  warning: '‼',
+};
+
+const figures = platform === 'win32' ? windows : main;
+
+module.exports = figures;

--- a/src/formatters/text_formatter.js
+++ b/src/formatters/text_formatter.js
@@ -1,5 +1,5 @@
 import columnify from 'columnify';
-import figures from 'figures';
+import figures from '../figures';
 import chalk from 'chalk';
 
 export default function TextFormatter(errorsGroupedByFile) {

--- a/src/runner.js
+++ b/src/runner.js
@@ -2,7 +2,7 @@ import { validateSchemaDefinition } from './validator.js';
 import { version } from '../package.json';
 import { Command } from 'commander';
 import { Configuration } from './configuration.js';
-import figures from 'figures';
+import figures from './figures';
 import chalk from 'chalk';
 
 export function run(stdout, stdin, stderr, argv) {

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -2,7 +2,6 @@ import assert from 'assert';
 import { parse } from 'graphql';
 import { validate } from 'graphql/validation';
 import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
-import { kebabCase } from 'lodash';
 import { validateSchemaDefinition } from '../src/validator.js';
 import { Configuration } from '../src/configuration.js';
 
@@ -32,7 +31,10 @@ export function expectFailsRuleWithConfiguration(
     errors,
     expectedErrors.map(expectedError => {
       return Object.assign(expectedError, {
-        ruleName: kebabCase(rule.name),
+        ruleName: rule.name
+          .replace(/([A-Z])/g, '-$1')
+          .toLowerCase()
+          .replace(/^-/, ''),
       });
     })
   );

--- a/test/formatters/text_formatter.js
+++ b/test/formatters/text_formatter.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import TextFormatter from '../../src/formatters/text_formatter';
-import figures from 'figures';
+import figures from '../../src/figures';
 const stripAnsi = require('strip-ansi');
 
 describe('TextFormatter', () => {


### PR DESCRIPTION
These two dependencies were barely used.

`figures` - I cherry-picked the figures we use out of the library.
`lodash` - We were only using `String.kebabcase` in an assertion helper, so I replaced it with a naive RegExp which should get the job done.