### PR TITLE
feat(config) remove aws directive from error check

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -93,11 +93,19 @@ export function run(stdout, stdin, stderr, argv) {
   const schemaSourceMap = configuration.getSchemaSourceMap();
 
   const errors = validateSchemaDefinition(schema, rules, configuration);
-  const groupedErrors = groupErrorsBySchemaFilePath(errors, schemaSourceMap);
+
+  const filteredErrors = errors.filter(({ message }) => {
+    return message !== 'Unknown directive "aws_subscribe".';
+  });
+
+  const groupedErrors = groupErrorsBySchemaFilePath(
+    filteredErrors,
+    schemaSourceMap
+  );
 
   stdout.write(formatter(groupedErrors));
 
-  return errors.length > 0 ? 1 : 0;
+  return filteredErrors.length > 0 ? 1 : 0;
 }
 
 function groupErrorsBySchemaFilePath(errors, schemaSourceMap) {


### PR DESCRIPTION
This PR is a temporary fix/hack to allow the linting to pass when linting AWS AppSync schema.

Currently the linting fails for the AWS subscriptions... for example:

```
# Subscription to the punter's event
addedEvent: Environment
@aws_subscribe(mutations: ["addEvent"])
```

Errors with the directive error below:

```
Unknown directive "aws_subscribe".  invalid-graphql-schema
```

TODO: investigate how we can add a custom role to the linter.