### PR TITLE
chore: upgrade dependency cosmiconfig to 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "chalk": "^2.0.1",
     "columnify": "^1.5.4",
     "commander": "^2.11.0",
-    "cosmiconfig": "^4.0.0",
+    "cosmiconfig": "^5.0.0",
     "glob": "^7.1.2",
     "graphql": "^14.0.0"
   },

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -177,8 +177,7 @@ function loadOptionsFromConfig(configDirectory) {
 
   const cosmic = cosmiconfig('graphql-schema-linter', {
     cache: false,
-    sync: true,
-  }).load(searchPath);
+  }).searchSync(searchPath);
 
   if (cosmic) {
     return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1349,15 +1349,15 @@ cosmiconfig@5.0.6:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
-cosmiconfig@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
-  integrity sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==
+cosmiconfig@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.2.0.tgz#45038e4d28a7fe787203aede9c25bca4a08b12c8"
+  integrity sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==
   dependencies:
+    import-fresh "^2.0.0"
     is-directory "^0.3.1"
-    js-yaml "^3.9.0"
+    js-yaml "^3.13.0"
     parse-json "^4.0.0"
-    require-from-string "^2.0.1"
 
 cosmiconfig@^5.0.7:
   version "5.0.7"
@@ -2513,6 +2513,14 @@ js-yaml@3.12.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.9.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
@@ -3508,11 +3516,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
-require-from-string@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.1.tgz#c545233e9d7da6616e9d59adfb39fc9f588676ff"
-  integrity sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=
 
 require-main-filename@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Bumps cosmiconfig by a major version.

PR #131 created by renovate was failing because of the changes to the API between the major versions. While I am not an expert on cosmiconfig, using the new `searchSync` method instead of `load` with the `sync` parameter on the cosmiconfig instance seems to be the minimal set of changes to get the tests to pass.

My motivation for taking this PR on was a bit self serving as version 4.0.0 of cosmiconfig included version 3.12.0 of `js-yaml`, which was identified as having some security vulnerabilities. I don't think this package or the ones I work on are actually vulnerable to this issue, but I honestly just feel better bumping the cosmiconfig version up.

@cjoudrey  If there's anything I'm missing in this PR let me know.