### PR TITLE
Gracefully handle missing query root in schema

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -4,6 +4,7 @@ import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 import { GraphQLError } from 'graphql/error';
 import { validateSDL } from 'graphql/validation/validate';
 import { validateSchema } from 'graphql/type/validate';
+import { ValidationError } from './validation_error';
 
 export function validateSchemaDefinition(
   schemaDefinition,
@@ -33,9 +34,11 @@ export function validateSchemaDefinition(
   if (schemaErrors.length > 0) {
     return sortErrors(
       schemaErrors.map(error => {
-        error.ruleName = 'invalid-graphql-schema';
-
-        return error;
+        return new ValidationError(
+          'invalid-graphql-schema',
+          error.message,
+          error.nodes
+        );
       })
     );
   }
@@ -51,9 +54,11 @@ export function validateSchemaDefinition(
   if (schemaErrors.length > 0) {
     return sortErrors(
       schemaErrors.map(error => {
-        error.ruleName = 'invalid-graphql-schema';
-
-        return error;
+        return new ValidationError(
+          'invalid-graphql-schema',
+          error.message,
+          error.nodes || ast
+        );
       })
     );
   }

--- a/test/fixtures/invalid-ast.graphql
+++ b/test/fixtures/invalid-ast.graphql
@@ -1,0 +1,11 @@
+type Query {
+  a: String
+}
+
+schema {
+  query: Query
+}
+
+schema {
+  mutation: Query
+}

--- a/test/fixtures/schema.missing-query-root.graphql
+++ b/test/fixtures/schema.missing-query-root.graphql
@@ -1,0 +1,4 @@
+type User {
+  id: ID!
+  email: String!
+}

--- a/test/runner.js
+++ b/test/runner.js
@@ -57,6 +57,42 @@ describe('Runner', () => {
       assert.equal(1, exitCode);
     });
 
+    it('validates schema when query root is missing', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        `${__dirname}/fixtures/schema.missing-query-root.graphql`,
+      ];
+
+      const exitCode = run(mockStdout, mockStdin, mockStderr, argv);
+
+      const expected =
+        `${__dirname}/fixtures/schema.missing-query-root.graphql\n` +
+        '1:1 Query root type must be provided.  invalid-graphql-schema\n' +
+        '\n' +
+        '✖ 1 error detected\n';
+
+      assert.equal(expected, stripAnsi(stdout));
+    });
+
+    it('validates schema when ast is invalid', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        `${__dirname}/fixtures/invalid-ast.graphql`,
+      ];
+
+      const exitCode = run(mockStdout, mockStdin, mockStderr, argv);
+
+      const expected =
+        `${__dirname}/fixtures/invalid-ast.graphql\n` +
+        '9:1 Must provide only one schema definition.  invalid-graphql-schema\n' +
+        '\n' +
+        '✖ 1 error detected\n';
+
+      assert.equal(expected, stripAnsi(stdout));
+    });
+
     it('returns exit code 0 when there are errors', () => {
       const argv = [
         'node',

--- a/test/validator.js
+++ b/test/validator.js
@@ -41,6 +41,21 @@ describe('validateSchemaDefinition', () => {
     assert.equal(1, errors.length);
   });
 
+  it('reports schema with missing query root', () => {
+    const schemaPath = `${__dirname}/fixtures/schema.missing-query-root.graphql`;
+    const configuration = new Configuration({ schemaPaths: [schemaPath] });
+
+    const schemaDefinition = configuration.getSchema();
+
+    const errors = validateSchemaDefinition(
+      schemaDefinition,
+      [],
+      configuration
+    );
+
+    assert.equal(1, errors.length);
+  });
+
   it('catches and returns GraphQL schema errors', () => {
     const schemaPath = `${__dirname}/fixtures/invalid-schema.graphql`;
     const configuration = new Configuration({ schemaPaths: [schemaPath] });


### PR DESCRIPTION
Fix #170 #172 #177 #188 

Currently if you run `graphql-schema-linter` against a schema that is missing a query root it will crash:

```
$ schema.missing-query-root.graphql
type User {
  id: ID!
  email: String!
}

$ graphql-schema-linter schema.missing-query-root.graphql
It looks like you may have hit a bug in graphql-schema-linter.

It would be super helpful if you could report this here: https://github.com/cjoudrey/graphql-schema-linter/issues/new

TypeError: Cannot read property '0' of undefined
    at /Users/cjoudrey/.config/yarn/global/node_modules/graphql-schema-linter/lib/runner.js:76:70
```

This pull requests attempts to fail more gracefully:

```
$ yarn prepare && node lib/cli.js test/fixtures/schema.missing-query-root.graphql
/Users/cjoudrey/code/cjoudrey/graphql-schema-linter/test/fixtures/schema.missing-query-root.graphql
1:1 Query root type must be provided.  invalid-graphql-schema

✖ 1 error detected
```