### PR TITLE
allow schemaPath to come from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ For now, only `rules`, `customRulePaths` and `schemaPaths` can be configured in 
 {
   "graphql-schema-linter": {
     "rules": ["enum-values-sorted-alphabetically"],
-    "schemaPaths": ["path/to/mySchemaFiles/**.graphql"],
-    "customRulePaths": ["path/to/myCustomRules/**.js"]
+    "schemaPaths": ["path/to/my/schema/files/**.graphql"],
+    "customRulePaths": ["path/to/my/custom/rules/*.js"]
   }
 }
 ```
@@ -163,8 +163,8 @@ For now, only `rules`, `customRulePaths` and `schemaPaths` can be configured in 
 ```json
 {
   "rules": ["enum-values-sorted-alphabetically"],
-  "schemaPaths": ["path/to/mySchemaFiles/**.graphql"],
-  "customRulePaths": ["path/to/myCustomRules/**.js"]
+  "schemaPaths": ["path/to/my/schema/files/**.graphql"],
+  "customRulePaths": ["path/to/my/custom/rules/*.js"]
 }
 ```
 
@@ -173,8 +173,8 @@ For now, only `rules`, `customRulePaths` and `schemaPaths` can be configured in 
 ```js
 module.exports = {
   rules: ['enum-values-sorted-alphabetically'],
-  schemaPaths: ['path/to/mySchemaFiles/**.graphql'],
-  customRulePaths: ['path/to/myCustomRules/**.js'],
+  schemaPaths: ['path/to/my/schema/files/**.graphql'],
+  customRulePaths: ['path/to/my/custom/rules/*.js'],
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Options:
 ### Usage with pre-commit Hooks
 
 Using [lint-staged](https://github.com/okonet/lint-staged) and [husky](https://github.com/typicode/husky), you can lint
-your staged GraphQL schema file before you commit.  First, install these packages:
+your staged GraphQL schema file before you commit. First, install these packages:
 
 ```bash
 yarn add --dev lint-staged husky
@@ -144,14 +144,16 @@ If you have multiple schemas in the same folder, your `lint-staged` configuratio
 In addition to being able to configure `graphql-schema-linter` via command line options, it can also be configured via
 one of the following configuration files.
 
-For now, only `rules` can be configured in a configuration file, but more options may be added in the future.
+For now, only `rules`, `customRulePaths` and `schemaPaths` can be configured in a configuration file, but more options may be added in the future.
 
 ### In `package.json`
 
 ```json
 {
   "graphql-schema-linter": {
-    "rules": ["enum-values-sorted-alphabetically"]
+    "rules": ["enum-values-sorted-alphabetically"],
+    "schemaPaths": ["path/to/mySchemaFiles/**.graphql"],
+    "customRulePaths": ["path/to/myCustomRules/**.js"]
   }
 }
 ```
@@ -160,7 +162,9 @@ For now, only `rules` can be configured in a configuration file, but more option
 
 ```json
 {
-  "rules": ["enum-values-sorted-alphabetically"]
+  "rules": ["enum-values-sorted-alphabetically"],
+  "schemaPaths": ["path/to/mySchemaFiles/**.graphql"],
+  "customRulePaths": ["path/to/myCustomRules/**.js"]
 }
 ```
 
@@ -169,6 +173,8 @@ For now, only `rules` can be configured in a configuration file, but more option
 ```js
 module.exports = {
   rules: ['enum-values-sorted-alphabetically'],
+  schemaPaths: ['path/to/mySchemaFiles/**.graphql'],
+  customRulePaths: ['path/to/myCustomRules/**.js'],
 };
 ```
 

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -95,7 +95,6 @@ export class Configuration {
   getRules() {
     let rules = this.getAllRules();
     let specifiedRules;
-    debugger;
     if (this.options.rules && this.options.rules.length > 0) {
       specifiedRules = this.options.rules.map(toUpperCamelCase);
       rules = this.getAllRules().filter(rule => {
@@ -230,7 +229,6 @@ function loadOptionsFromConfig(configDirectory) {
       );
     }
 
-    debugger;
     return {
       rules: cosmic.config.rules,
       customRulePaths: customRulePaths || [],

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -1,4 +1,4 @@
-const cosmiconfig = require('cosmiconfig');
+import cosmiconfig from 'cosmiconfig';
 import { readSync, readFileSync } from 'fs';
 import path from 'path';
 import { sync as globSync, hasMagic as globHasMagic } from 'glob';
@@ -95,6 +95,7 @@ export class Configuration {
   getRules() {
     let rules = this.getAllRules();
     let specifiedRules;
+    debugger;
     if (this.options.rules && this.options.rules.length > 0) {
       specifiedRules = this.options.rules.map(toUpperCamelCase);
       rules = this.getAllRules().filter(rule => {
@@ -212,17 +213,27 @@ function loadOptionsFromConfig(configDirectory) {
 
   if (cosmic) {
     let schemaPaths = [];
+    let customRulePaths = [];
 
-    // If schemaPaths comes from cosmic, we resolve the given paths relative to the searchPath.
+    // If schemaPaths come from cosmic, we resolve the given paths relative to the searchPath.
 
     if (cosmic.config.schemaPaths) {
       schemaPaths = cosmic.config.schemaPaths.map(schemaPath =>
         path.resolve(searchPath, schemaPath)
       );
     }
+
+    // If customRulePaths come from cosmic, we resolve the given paths relative to the searchPath.
+    if (cosmic.config.customRulePaths) {
+      customRulePaths = cosmic.config.customRulePaths.map(schemaPath =>
+        path.resolve(searchPath, schemaPath)
+      );
+    }
+
+    debugger;
     return {
       rules: cosmic.config.rules,
-      customRulePaths: cosmic.config.customRulePaths || [],
+      customRulePaths: customRulePaths || [],
       schemaPaths: schemaPaths,
     };
   } else {

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -60,8 +60,11 @@ export class Configuration {
 
       this.sourceMap = new SourceMap({ stdin: this.schema });
     } else if (this.options.schemaPaths) {
-      const expandedPaths = expandPaths(this.options.schemaPaths);
+      let schemaPaths = this.options.schemaPaths;
+
+      const expandedPaths = expandPaths(schemaPaths);
       const segments = getSchemaSegmentsFromFiles(expandedPaths);
+
       if (Object.keys(segments).length === 0) {
         return null;
       }
@@ -208,9 +211,19 @@ function loadOptionsFromConfig(configDirectory) {
   }).searchSync(searchPath);
 
   if (cosmic) {
+    let schemaPaths = [];
+
+    // If schemaPaths comes from cosmic, we resolve the given paths relative to the searchPath.
+
+    if (cosmic.config.schemaPaths) {
+      schemaPaths = cosmic.config.schemaPaths.map(schemaPath =>
+        path.resolve(searchPath, schemaPath)
+      );
+    }
     return {
       rules: cosmic.config.rules,
       customRulePaths: cosmic.config.customRulePaths || [],
+      schemaPaths: schemaPaths,
     };
   } else {
     return {};

--- a/test/config/package_json/package.json
+++ b/test/config/package_json/package.json
@@ -1,5 +1,10 @@
 {
   "graphql-schema-linter": {
-    "rules": ["enum-values-sorted-alphabetically"]
+    "rules": [
+      "enum-values-sorted-alphabetically"
+    ],
+    "schemaPaths": [
+      "../../fixtures/schema.graphql"
+    ]
   }
 }

--- a/test/config/package_json/package.json
+++ b/test/config/package_json/package.json
@@ -1,7 +1,11 @@
 {
   "graphql-schema-linter": {
     "rules": [
-      "enum-values-sorted-alphabetically"
+      "enum-values-sorted-alphabetically",
+      "SomeRule"
+    ],
+    "customRulePaths": [
+      "../../fixtures/custom_rules/*.js"
     ],
     "schemaPaths": [
       "../../fixtures/schema.graphql"

--- a/test/config/package_json/test.js
+++ b/test/config/package_json/test.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { readSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import assert from 'assert';
 import { Configuration } from '../../../src/configuration';
 

--- a/test/config/package_json/test.js
+++ b/test/config/package_json/test.js
@@ -1,3 +1,5 @@
+import path from 'path';
+import { readSync, readFileSync } from 'fs';
 import assert from 'assert';
 import { Configuration } from '../../../src/configuration';
 
@@ -10,12 +12,40 @@ describe('Config', () => {
 
       const rules = configuration.getRules();
 
-      assert.equal(rules.length, 1);
+      assert.equal(2, rules.length);
       assert.equal(
         1,
         rules.filter(rule => {
           return rule.name == 'EnumValuesSortedAlphabetically';
         }).length
+      );
+    });
+  });
+
+  describe('customRulePaths', () => {
+    it('pulls customRulePaths from package.json', () => {
+      const configuration = new Configuration({
+        configDirectory: __dirname,
+      });
+
+      const rules = configuration.getRules();
+
+      assert.equal(rules.filter(({ name }) => name === 'SomeRule').length, 1);
+    });
+  });
+
+  describe('schemaPaths', () => {
+    it('pulls schemaPaths from package.json when configDirectory is provided', () => {
+      const fixturePath = path.join(
+        __dirname,
+        '/../../fixtures/schema.graphql'
+      );
+      const configuration = new Configuration({
+        configDirectory: __dirname,
+      });
+      assert.equal(
+        configuration.getSchema(),
+        readFileSync(fixturePath).toString('utf8')
       );
     });
   });

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { Configuration } from '../src/configuration.js';
 import JSONFormatter from '../src/formatters/json_formatter.js';
 import TextFormatter from '../src/formatters/text_formatter.js';
+import path from 'path';
 import { openSync, readFileSync } from 'fs';
 import { relative as pathRelative } from 'path';
 
@@ -35,6 +36,17 @@ extend type Query {
 `;
 
       assert.equal(configuration.getSchema(), expectedSchema);
+    });
+
+    it('reads schema from package.json when configDirectory is provided', () => {
+      const fixturePath = `${__dirname}/fixtures/schema.graphql`;
+      const configuration = new Configuration({
+        configDirectory: path.join(`${__dirname}/config/package_json`),
+      });
+      assert.equal(
+        configuration.getSchema(),
+        readFileSync(fixturePath).toString('utf8')
+      );
     });
 
     it('reads schema from file when provided', () => {

--- a/test/configuration.js
+++ b/test/configuration.js
@@ -2,7 +2,6 @@ import assert from 'assert';
 import { Configuration } from '../src/configuration.js';
 import JSONFormatter from '../src/formatters/json_formatter.js';
 import TextFormatter from '../src/formatters/text_formatter.js';
-import path from 'path';
 import { openSync, readFileSync } from 'fs';
 import { relative as pathRelative } from 'path';
 
@@ -36,17 +35,6 @@ extend type Query {
 `;
 
       assert.equal(configuration.getSchema(), expectedSchema);
-    });
-
-    it('reads schema from package.json when configDirectory is provided', () => {
-      const fixturePath = `${__dirname}/fixtures/schema.graphql`;
-      const configuration = new Configuration({
-        configDirectory: path.join(`${__dirname}/config/package_json`),
-      });
-      assert.equal(
-        configuration.getSchema(),
-        readFileSync(fixturePath).toString('utf8')
-      );
     });
 
     it('reads schema from file when provided', () => {


### PR DESCRIPTION
👋 Thanks for creating `graphql-schema-linter`. 

We are using it to lint our schemas and we would like to have everything (when possible) in our `package.json`, particularly we noticed that  `SchemaPath` can only be provided via the command line or programatically but not via the configuration. 

this PR provides `schemaPaths` as part of the configuration.   