### PR TITLE
moving config from pre-commit on scripts to husky.hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,14 @@
   "author": "Christian Joudrey",
   "main": "lib/index.js",
   "scripts": {
-    "precommit": "lint-staged",
     "test": "mocha test/index.js",
     "prepare": "rm -rf lib/* && babel ./src --ignore test --out-dir ./lib"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged",
+      "pre-push": "yarn test"
+    }
   },
   "pkg": {
     "scripts": "lib/**/*.js"


### PR DESCRIPTION
Working on the test helper on #197 I saw husky complaining about configuration issues, so I fixed it. 

I've added the tests when we push in hopes that this will prevent (me or others?) to PR a branch without the test suite passing. 