### PR TITLE
allow non-nullable first and last arguments in relay-connection-arguments-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,9 +236,7 @@ More specifically:
 - To enable forward pagination, two arguments are required: `first: Int` and `after: *`.
 - To enable backward pagination, two arguments are required: `last: Int` and `before: *`.
 
-Note: If only forward pagination is enabled, the `first` argument be specified as non-nullable (i.e., `Int!` instead of `Int`). Similarly, if only backward pagination is enabled, the `last` argument can be specified as non-nullable.
-
-### `relay-page-info-spec`
+Note: If only forward pagination is enabled, the `first` argument can be specified as non-nullable (i.e., `Int!` instead of `Int`). Similarly, if only backward pagination is enabled, the `last` argument can be specified as non-nullable.
 
 This rule will validate the schema adheres to [section 5 (PageInfo)](https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo) of the [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm).
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ More specifically:
 - To enable forward pagination, two arguments are required: `first: Int` and `after: *`.
 - To enable backward pagination, two arguments are required: `last: Int` and `before: *`.
 
+Note: If only forward pagination is enabled, the `first` argument be specified as non-nullable (i.e., `Int!` instead of `Int`). Similarly, if only backward pagination is enabled, the `last` argument can be specified as non-nullable.
+
 ### `relay-page-info-spec`
 
 This rule will validate the schema adheres to [section 5 (PageInfo)](https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo) of the [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm).

--- a/src/rules/relay_connection_arguments_spec.js
+++ b/src/rules/relay_connection_arguments_spec.js
@@ -46,32 +46,70 @@ export function RelayConnectionArgumentsSpec(context) {
       }
 
       if (firstArgument) {
-        if (
-          firstArgument.type.kind != 'NamedType' ||
-          firstArgument.type.name.value != 'Int'
-        ) {
-          return context.reportError(
-            new ValidationError(
-              'relay-connection-arguments-spec',
-              'Fields that support forward pagination must include a `first` argument that takes a non-negative integer as per the Relay spec.',
-              [firstArgument]
-            )
-          );
+        if (hasBackwardPagination) {
+          // first and last must be nullable if both forward and backward pagination are supported.
+          if (
+            firstArgument.type.kind != 'NamedType' ||
+            firstArgument.type.name.value != 'Int'
+          ) {
+            return context.reportError(
+              new ValidationError(
+                'relay-connection-arguments-spec',
+                'Fields that support forward and backward pagination must include a `first` argument that takes a nullable non-negative integer as per the Relay spec.',
+                [firstArgument]
+              )
+            );
+          }
+        } else {
+          // first can be non-nullable if only forward pagination is supported.
+          const isFirstArgumentNullable =
+            firstArgument.type.kind !== 'NonNullType';
+          const type = isFirstArgumentNullable
+            ? firstArgument.type
+            : firstArgument.type.type;
+          if (type.kind != 'NamedType' || type.name.value != 'Int') {
+            return context.reportError(
+              new ValidationError(
+                'relay-connection-arguments-spec',
+                'Fields that support forward pagination must include a `first` argument that takes a non-negative integer as per the Relay spec.',
+                [firstArgument]
+              )
+            );
+          }
         }
       }
 
       if (lastArgument) {
-        if (
-          lastArgument.type.kind != 'NamedType' ||
-          lastArgument.type.name.value != 'Int'
-        ) {
-          return context.reportError(
-            new ValidationError(
-              'relay-connection-arguments-spec',
-              'Fields that support forward pagination must include a `last` argument that takes a non-negative integer as per the Relay spec.',
-              [lastArgument]
-            )
-          );
+        if (hasForwardPagination) {
+          // first and last must be nullable if both forward and backward pagination are supported.
+          if (
+            lastArgument.type.kind != 'NamedType' ||
+            lastArgument.type.name.value != 'Int'
+          ) {
+            return context.reportError(
+              new ValidationError(
+                'relay-connection-arguments-spec',
+                'Fields that support forward and backward pagination must include a `last` argument that takes a nullable non-negative integer as per the Relay spec.',
+                [lastArgument]
+              )
+            );
+          }
+        } else {
+          // last can be non-nullable if only backward pagination is supported.
+          const isLastArgumentNullable =
+            lastArgument.type.kind !== 'NonNullType';
+          const type = isLastArgumentNullable
+            ? lastArgument.type
+            : lastArgument.type.type;
+          if (type.kind != 'NamedType' || type.name.value != 'Int') {
+            return context.reportError(
+              new ValidationError(
+                'relay-connection-arguments-spec',
+                'Fields that support backward pagination must include a `last` argument that takes a non-negative integer as per the Relay spec.',
+                [lastArgument]
+              )
+            );
+          }
         }
       }
     },

--- a/src/rules/relay_connection_arguments_spec.js
+++ b/src/rules/relay_connection_arguments_spec.js
@@ -62,11 +62,7 @@ export function RelayConnectionArgumentsSpec(context) {
           }
         } else {
           // first can be non-nullable if only forward pagination is supported.
-          const isFirstArgumentNullable =
-            firstArgument.type.kind !== 'NonNullType';
-          const type = isFirstArgumentNullable
-            ? firstArgument.type
-            : firstArgument.type.type;
+          const type = unwrapType(firstArgument.type);
           if (type.kind != 'NamedType' || type.name.value != 'Int') {
             return context.reportError(
               new ValidationError(
@@ -96,11 +92,7 @@ export function RelayConnectionArgumentsSpec(context) {
           }
         } else {
           // last can be non-nullable if only backward pagination is supported.
-          const isLastArgumentNullable =
-            lastArgument.type.kind !== 'NonNullType';
-          const type = isLastArgumentNullable
-            ? lastArgument.type
-            : lastArgument.type.type;
+          const type = unwrapType(lastArgument.type);
           if (type.kind != 'NamedType' || type.name.value != 'Int') {
             return context.reportError(
               new ValidationError(

--- a/test/rules/relay_connection_arguments_spec.js
+++ b/test/rules/relay_connection_arguments_spec.js
@@ -74,6 +74,90 @@ describe('RelayConnectionArgumentsSpec rule', () => {
     );
   });
 
+  it('accepts connection with required first argument if no backward pagination is specified', () => {
+    expectPassesRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(first: Int!, after: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `
+    );
+  });
+
+  it('accepts connection with required last argument if no forward pagination is specified', () => {
+    expectPassesRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(last: Int!, before: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `
+    );
+  });
+
+  it('reports invalid first argument if first is required and backward pagination is specified', () => {
+    expectFailsRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(first: Int!, after: String, last: Int, before: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `,
+      [
+        {
+          locations: [
+            {
+              column: 15,
+              line: 3,
+            },
+          ],
+          message:
+            'Fields that support forward and backward pagination must include a `first` argument that takes a nullable non-negative integer as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
+  it('reports invalid last argument if last is required and forward pagination is specified', () => {
+    expectFailsRule(
+      RelayConnectionArgumentsSpec,
+      `
+      extend type Query {
+        users(first: Int, after: String, last: Int!, before: String): UserConnection
+      }
+
+      type UserConnection {
+        a: String
+      }
+    `,
+      [
+        {
+          locations: [
+            {
+              column: 42,
+              line: 3,
+            },
+          ],
+          message:
+            'Fields that support forward and backward pagination must include a `last` argument that takes a nullable non-negative integer as per the Relay spec.',
+        },
+      ]
+    );
+  });
+
   it('reports invalid first argument', () => {
     expectFailsRule(
       RelayConnectionArgumentsSpec,
@@ -122,7 +206,7 @@ describe('RelayConnectionArgumentsSpec rule', () => {
             },
           ],
           message:
-            'Fields that support forward pagination must include a `last` argument that takes a non-negative integer as per the Relay spec.',
+            'Fields that support backward pagination must include a `last` argument that takes a non-negative integer as per the Relay spec.',
         },
       ]
     );

--- a/test/rules/relay_connection_arguments_spec.js
+++ b/test/rules/relay_connection_arguments_spec.js
@@ -59,7 +59,7 @@ describe('RelayConnectionArgumentsSpec rule', () => {
     );
   });
 
-  it('accepts connection with proper foward and backward pagination arguments', () => {
+  it('accepts connection with proper forward and backward pagination arguments', () => {
     expectPassesRule(
       RelayConnectionArgumentsSpec,
       `


### PR DESCRIPTION
This addresses https://github.com/cjoudrey/graphql-schema-linter/issues/148.

The `first` argument type in a Relay connection can now be non-nullable if backward pagination is disabled (likewise for `last` when forward pagination is disabled). So the following types are now permitted:

```
type Query {
  users(last: Int!, before: String): UserConnection
}
```

```
type Query {
  users(first: Int!, after: String): UserConnection
}
```

The following, however, are not permitted:

```
type Query {
  users(first: Int!, after: String, last: Int, before: String): UserConnection
}
```

```
type Query {
  users(first: Int, after: String, last: Int!, before: String): UserConnection
}
```