### PR TITLE
Add option to print config

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -46,6 +46,10 @@ export function run(stdout, stdin, stderr, argv) {
       '-e, --except <rules>',
       'This option is DEPRECATED. Use `--rules` instead.'
     )
+    .option(
+      '--print-config',
+      'print the configuration if valid and exit with 0'
+    )
     .version(version, '--version')
     .parse(argv);
 
@@ -83,6 +87,12 @@ export function run(stdout, stdin, stderr, argv) {
     return 2;
   }
 
+  if (commander.printConfig) {
+    const { schema, sourceMap, stdinFd, ...strippedConfig } = configuration;
+    stdout.write(JSON.stringify(strippedConfig, stringifyRule, 2) + '\n');
+    return 0;
+  }
+
   const schema = configuration.getSchema();
   if (schema == null) {
     console.error('No valid schema input.');
@@ -98,6 +108,13 @@ export function run(stdout, stdin, stderr, argv) {
   stdout.write(formatter(groupedErrors));
 
   return errors.length > 0 ? 1 : 0;
+}
+
+function stringifyRule(key, value) {
+  if (typeof value === 'function') {
+    return value.name;
+  }
+  return value;
 }
 
 function groupErrorsBySchemaFilePath(errors, schemaSourceMap) {

--- a/test/runner.js
+++ b/test/runner.js
@@ -430,5 +430,35 @@ describe('Runner', () => {
       );
       assert.equal(0, exitCode);
     });
+
+    it('prints config and exits with 0 if config is valid', () => {
+      const argv = [
+        'node',
+        'lib/cli.js',
+        '--print-config',
+        '--rules',
+        'no-rule-of-mine,fields-have-descriptions',
+        '--stdin',
+        'foo.graphql',
+        '--format',
+        'json',
+        '--custom-rule-paths',
+        `${__dirname}/fixtures/custom_rules/*`,
+      ];
+
+      const exitCode = run(mockStdout, mockStdin, mockStderr, argv);
+      assert.strictEqual(exitCode, 0);
+
+      const config = JSON.parse(stdout);
+      assert(config.options.stdin);
+      assert.strictEqual(config.options.format, 'json');
+      assert(!config.options.commentDescriptions);
+      assert(!config.options.oldImplementsSyntax);
+      assert.strictEqual(config.options.customRulePaths.length, 1);
+      assert.strictEqual(config.options.rules.length, 2);
+      assert(config.rules.length > 0);
+      assert(config.builtInRulePaths);
+      assert.strictEqual(config.rulePaths.length, 2);
+    });
   });
 });


### PR DESCRIPTION
New option to just print the configuration for feedback to the user.
If the config is not valid, the runner does what it did before and
exits with 2 after displaying the errors.

When the option is set,the linter prints the options, rules, and
paths it would use and exits with a 0 status.