### PR TITLE
Add customRulePackages config option

### DIFF
--- a/src/relative_module_resolver.js
+++ b/src/relative_module_resolver.js
@@ -1,0 +1,42 @@
+/**
+ * Utility for resolving a module relative to another module
+ * @author Teddy Katz
+ * Copied from https://github.com/eslint/eslint/blob/master/lib/shared/relative-module-resolver.js
+ */
+
+'use strict';
+
+const Module = require('module');
+
+/*
+ * `Module.createRequire` is added in v12.2.0. It supports URL as well.
+ * We only support the case where the argument is a filepath, not a URL.
+ */
+const createRequire = Module.createRequire || Module.createRequireFromPath;
+
+module.exports = {
+  /**
+   * Resolves a Node module relative to another module
+   * @param {string} moduleName The name of a Node module, or a path to a Node module.
+   * @param {string} relativeToPath An absolute path indicating the module that `moduleName` should be resolved relative to. This must be
+   * a file rather than a directory, but the file need not actually exist.
+   * @returns {string} The absolute path that would result from calling `require.resolve(moduleName)` in a file located at `relativeToPath`
+   */
+  resolve(moduleName, relativeToPath) {
+    try {
+      return createRequire(relativeToPath).resolve(moduleName);
+    } catch (error) {
+      // This `if` block is for older Node.js than 12.0.0. We can remove this block in the future.
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        error.code === 'MODULE_NOT_FOUND' &&
+        !error.requireStack &&
+        error.message.includes(moduleName)
+      ) {
+        error.message += `\nRequire stack:\n- ${relativeToPath}`;
+      }
+      throw error;
+    }
+  },
+};


### PR DESCRIPTION
This is not quite what I proposed in #217 . Adding full `extends` proved a bit tricky so I concentrated on the most important thing: ability to distribute custom rules in an NPM package.

Added `customRulePackages` config option. It works like `customRulePaths` except you list NPM package names. It assumes that the named exports from each package's main entry file are each rules. You have to npm/yarn install any packages you list.

## Testing
1. `npm link` or `yarn link` this branch into your project that uses `graphql-schema-linter`
1. Create a folder `gqlsl-custom-rules` in `node_modules` in the project
1. Add `index.js` file in that folder and export at least one rule from it
1. Add `customRulePackages: ["gqlsl-custom-rules"]` in your `graphql-schema-linter` config file for the project
1. Add the custom rules to `rules` list in your `graphql-schema-linter` config file for the project. Must match the name of the export.
1. Run schema linting and check that you don't get any warnings about missing rules.

## Notes
The `relative_module_resolver.js` file I added is from https://github.com/eslint/eslint/blob/master/lib/shared/relative-module-resolver.js. Both packages are MIT licensed so this should be fine.

Not ready to merge yet. I will add documentation after the questions below are answered.

## Questions
- Does this implementation seem good?
- I added the new option to the config resolver but not to the CLI command options. Should it be added to CLI, too?
- Unsure how best to write tests for this. Should I build a whole project in a temp dir and "install" a fake package in `node_modules` and then programmatically run the check?