### PR TITLE
Inline configuration support

### DIFF
--- a/src/inline_configuration.js
+++ b/src/inline_configuration.js
@@ -1,0 +1,52 @@
+export function extractInlineConfigs(ast) {
+  var configurations = [];
+
+  var token = ast.loc.startToken;
+
+  while (token) {
+    if (token.kind == 'Comment' && token.value.startsWith(' lint-')) {
+      const previousToken = token.prev;
+      const nextToken = token.next;
+
+      previousToken.next = nextToken;
+      nextToken.prev = previousToken;
+
+      configurations.push(parseInlineComment(token));
+    }
+
+    token = token.next;
+  }
+
+  return configurations;
+}
+
+function parseInlineComment(token) {
+  const matches = /^\s{0,}(lint-[^\s]+)(\s(.*))?$/g.exec(token.value);
+
+  switch (matches[1]) {
+    case 'lint-enable':
+      return {
+        command: 'enable',
+        rules: parseRulesArg(matches[3]),
+        line: token.line,
+      };
+
+    case 'lint-disable':
+      return {
+        command: 'disable',
+        rules: parseRulesArg(matches[3]),
+        line: token.line,
+      };
+
+    case 'lint-disable-line':
+      return {
+        command: 'disable-line',
+        rules: parseRulesArg(matches[3]),
+        line: token.line,
+      };
+  }
+}
+
+function parseRulesArg(value) {
+  return value.split(/\,\s+/);
+}

--- a/src/runner.js
+++ b/src/runner.js
@@ -81,7 +81,7 @@ export async function run(stdout, stdin, stderr, argv) {
 
   const issues = configuration.validate();
 
-  issues.map(issue => {
+  issues.map((issue) => {
     var prefix;
     if (issue.type == 'error') {
       prefix = `${chalk.red(figures.cross)} Error`;
@@ -93,18 +93,14 @@ export async function run(stdout, stdin, stderr, argv) {
     );
   });
 
-  if (issues.some(issue => issue.type == 'error')) {
+  if (issues.some((issue) => issue.type == 'error')) {
     return 2;
   }
 
   const formatter = configuration.getFormatter();
   const rules = configuration.getRules();
 
-  const errors = validateSchemaDefinition(
-    schema.definition,
-    rules,
-    configuration
-  );
+  const errors = validateSchemaDefinition(schema, rules, configuration);
   const groupedErrors = groupErrorsBySchemaFilePath(errors, schema.sourceMap);
 
   stdout.write(formatter(groupedErrors));

--- a/src/validator.js
+++ b/src/validator.js
@@ -83,6 +83,16 @@ function sortErrors(errors) {
   });
 }
 
+function ruleWithConfiguration(rule, configuration) {
+  if (rule.length == 2) {
+    return function (context) {
+      return rule(configuration, context);
+    };
+  } else {
+    return rule;
+  }
+}
+
 function applyInlineConfig(errors, schemaSourceMap, inlineConfigs) {
   if (inlineConfigs.length === 0) {
     return errors;
@@ -121,14 +131,4 @@ function applyInlineConfig(errors, schemaSourceMap, inlineConfigs) {
 
     return shouldApplyRule;
   });
-}
-
-function ruleWithConfiguration(rule, configuration) {
-  if (rule.length == 2) {
-    return function (context) {
-      return rule(configuration, context);
-    };
-  } else {
-    return rule;
-  }
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -6,7 +6,6 @@ import { validateSDL } from 'graphql/validation/validate';
 import { validateSchema } from 'graphql/type/validate';
 import { extractInlineConfigs } from './inline_configuration';
 import { ValidationError } from './validation_error';
-import { command } from 'commander';
 
 export function validateSchemaDefinition(inputSchema, rules, configuration) {
   let ast;

--- a/src/validator.js
+++ b/src/validator.js
@@ -4,13 +4,10 @@ import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 import { GraphQLError } from 'graphql/error';
 import { validateSDL } from 'graphql/validation/validate';
 import { validateSchema } from 'graphql/type/validate';
+import { extractInlineConfigs } from './inline_configuration';
 import { ValidationError } from './validation_error';
 
-export function validateSchemaDefinition(
-  schemaDefinition,
-  rules,
-  configuration
-) {
+export function validateSchemaDefinition(inputSchema, rules, configuration) {
   let ast;
 
   let parseOptions = {};
@@ -19,7 +16,7 @@ export function validateSchemaDefinition(
   }
 
   try {
-    ast = parse(schemaDefinition, parseOptions);
+    ast = parse(inputSchema.definition, parseOptions);
   } catch (e) {
     if (e instanceof GraphQLError) {
       e.ruleName = 'graphql-syntax-error';
@@ -33,7 +30,7 @@ export function validateSchemaDefinition(
   let schemaErrors = validateSDL(ast);
   if (schemaErrors.length > 0) {
     return sortErrors(
-      schemaErrors.map(error => {
+      schemaErrors.map((error) => {
         return new ValidationError(
           'invalid-graphql-schema',
           error.message,
@@ -53,7 +50,7 @@ export function validateSchemaDefinition(
   schemaErrors = validateSchema(schema);
   if (schemaErrors.length > 0) {
     return sortErrors(
-      schemaErrors.map(error => {
+      schemaErrors.map((error) => {
         return new ValidationError(
           'invalid-graphql-schema',
           error.message,
@@ -63,7 +60,7 @@ export function validateSchemaDefinition(
     );
   }
 
-  const rulesWithConfiguration = rules.map(rule => {
+  const rulesWithConfiguration = rules.map((rule) => {
     return ruleWithConfiguration(rule, configuration);
   });
 
@@ -81,7 +78,7 @@ function sortErrors(errors) {
 
 function ruleWithConfiguration(rule, configuration) {
   if (rule.length == 2) {
-    return function(context) {
+    return function (context) {
       return rule(configuration, context);
     };
   } else {

--- a/src/validator.js
+++ b/src/validator.js
@@ -6,6 +6,7 @@ import { validateSDL } from 'graphql/validation/validate';
 import { validateSchema } from 'graphql/type/validate';
 import { extractInlineConfigs } from './inline_configuration';
 import { ValidationError } from './validation_error';
+import { command } from 'commander';
 
 export function validateSchemaDefinition(inputSchema, rules, configuration) {
   let ast;
@@ -125,7 +126,11 @@ function applyInlineConfig(errors, schemaSourceMap, inlineConfigs) {
 
       // Otherwise, last command wins (expected order by line)
       if (config.line < errorLine) {
-        shouldApplyRule = config.command === 'enable';
+        if (config.command === 'enable') {
+          shouldApplyRule = true;
+        } else if (config.command === 'disable') {
+          shouldApplyRule = false;
+        }
       }
     }
 

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -30,7 +30,7 @@ export function expectFailsRuleWithConfiguration(
 
   assert.deepEqual(
     errors,
-    expectedErrors.map(expectedError => {
+    expectedErrors.map((expectedError) => {
       return Object.assign(expectedError, {
         ruleName: rule.name
           .replace(/([A-Z])/g, '-$1')
@@ -62,11 +62,7 @@ function validateSchemaWithRule(rule, schemaSDL, configurationOptions) {
   const rules = [rule];
   const schema = new Schema(`${schemaSDL}${DefaultSchema}`, null);
   const configuration = new Configuration(schema, configurationOptions);
-  const errors = validateSchemaDefinition(
-    schema.definition,
-    rules,
-    configuration
-  );
+  const errors = validateSchemaDefinition(schema, rules, configuration);
 
   return errors;
 }

--- a/test/fixtures/schema/inline-config.graphql
+++ b/test/fixtures/schema/inline-config.graphql
@@ -1,0 +1,12 @@
+# lint-disable fields-have-descriptions
+extend type Query {
+  comments: [Comment!]!
+}
+# lint-enable fields-have-descriptions
+
+type Post {
+  id: ID!
+  title: String! # lint-disable-line fields-have-descriptions
+  description: String!
+  author: User!
+}

--- a/test/index.js
+++ b/test/index.js
@@ -8,6 +8,7 @@ require('./runner');
 require('./schema');
 require('./source_map');
 require('./validator');
+require('./inline_configuration');
 require('./rules/arguments_have_descriptions');
 require('./rules/defined_types_are_used');
 require('./rules/deprecations_have_a_reason');

--- a/test/inline_configuration.js
+++ b/test/inline_configuration.js
@@ -1,0 +1,135 @@
+import assert from 'assert';
+import { parse } from 'graphql';
+import { extractInlineConfigs } from '../src/inline_configuration';
+
+describe('extractInlineConfigs', () => {
+  it('removes Comment tokens that are inline configs', () => {
+    const ast = parse(`
+      # lint-disable types-have-descriptions
+      type Query {
+        viewer: User!
+      }
+
+      # lint-enable types-have-descriptions
+      # User description
+      type User {
+        email: String! # lint-disable-line fields-have-descriptions
+      }
+`);
+
+    const previousTokens = astToTokens(ast);
+    extractInlineConfigs(ast);
+    const afterTokens = astToTokens(ast);
+
+    assert.equal(3, previousTokens.filter(inlineConfigurationToken).length);
+    assert.equal(0, afterTokens.filter(inlineConfigurationToken).length);
+
+    assert.equal('<SOF>', afterTokens[0].kind);
+    assert.equal('type', afterTokens[0].next.value);
+  });
+
+  it('extracts lint-enable configuration', () => {
+    const ast = parse(`
+      type Query {
+        viewer: User!
+      }
+
+      # lint-enable types-have-descriptions
+      # User description
+      type User {
+        # lint-enable fields-have-descriptions, types-have-descriptions
+        email: String!
+      }
+`);
+
+    const configs = extractInlineConfigs(ast);
+
+    assert.deepEqual(
+      [
+        { command: 'enable', rules: ['types-have-descriptions'], line: 6 },
+        {
+          command: 'enable',
+          rules: ['fields-have-descriptions', 'types-have-descriptions'],
+          line: 9,
+        },
+      ],
+      configs
+    );
+  });
+
+  it('extracts lint-disable configuration', () => {
+    const ast = parse(`
+      type Query {
+        viewer: User!
+      }
+
+      # lint-disable types-have-descriptions, another-rule
+      # User description
+      type User {
+        # lint-disable fields-have-descriptions
+        email: String!
+      }
+`);
+
+    const configs = extractInlineConfigs(ast);
+
+    assert.deepEqual(
+      [
+        {
+          command: 'disable',
+          rules: ['types-have-descriptions', 'another-rule'],
+          line: 6,
+        },
+        { command: 'disable', rules: ['fields-have-descriptions'], line: 9 },
+      ],
+      configs
+    );
+  });
+
+  it('extracts lint-disable-line configuration', () => {
+    const ast = parse(`
+      type Query {
+        viewer: User!
+      }
+
+      # User description
+      type User { # lint-disable-line types-have-descriptions, another-rule
+        email: String! # lint-disable-line fields-have-descriptions
+      }
+`);
+
+    const configs = extractInlineConfigs(ast);
+
+    assert.deepEqual(
+      [
+        {
+          command: 'disable-line',
+          rules: ['types-have-descriptions', 'another-rule'],
+          line: 7,
+        },
+        {
+          command: 'disable-line',
+          rules: ['fields-have-descriptions'],
+          line: 8,
+        },
+      ],
+      configs
+    );
+  });
+});
+
+function astToTokens(ast) {
+  var tokens = [];
+  var token = ast.loc.startToken;
+
+  while (token) {
+    tokens.push(token);
+    token = token.next;
+  }
+
+  return tokens;
+}
+
+function inlineConfigurationToken(token) {
+  return token.kind == 'Comment' && token.value.startsWith(' lint-');
+}

--- a/test/runner.js
+++ b/test/runner.js
@@ -7,14 +7,14 @@ import { stripAnsi } from './strip_ansi.js';
 describe('Runner', () => {
   var stdout;
   var mockStdout = {
-    write: text => {
+    write: (text) => {
       stdout = stdout + text;
     },
   };
 
   var stderr;
   var mockStderr = {
-    write: text => {
+    write: (text) => {
       stderr = stderr + text;
     },
   };
@@ -269,7 +269,7 @@ describe('Runner', () => {
 
       var errors = JSON.parse(stdout)['errors'];
       assert(errors);
-      assert.equal(6, errors.length);
+      assert.equal(9, errors.length);
     });
 
     it('validates a schema composed of multiple files (args) and outputs in json', async () => {

--- a/test/schema.js
+++ b/test/schema.js
@@ -12,6 +12,19 @@ describe('loadSchema', () => {
   author: User!
 }
 
+# lint-disable fields-have-descriptions
+extend type Query {
+  comments: [Comment!]!
+}
+# lint-enable fields-have-descriptions
+
+type Post {
+  id: ID!
+  title: String! # lint-disable-line fields-have-descriptions
+  description: String!
+  author: User!
+}
+
 type Query {
   something: String!
 }

--- a/test/validator.js
+++ b/test/validator.js
@@ -18,7 +18,7 @@ describe('validateSchemaDefinition', () => {
       return error.locations[0].line;
     });
 
-    assert.equal(7, errors.length);
+    assert.equal(10, errors.length);
 
     assert.deepEqual(errorLineNumbers.sort(), errorLineNumbers);
   });

--- a/test/validator.js
+++ b/test/validator.js
@@ -13,12 +13,8 @@ describe('validateSchemaDefinition', () => {
 
     const rules = [FieldsHaveDescriptions, DummyValidator];
 
-    const errors = validateSchemaDefinition(
-      schema.definition,
-      rules,
-      configuration
-    );
-    const errorLineNumbers = errors.map(error => {
+    const errors = validateSchemaDefinition(schema, rules, configuration);
+    const errorLineNumbers = errors.map((error) => {
       return error.locations[0].line;
     });
 
@@ -32,11 +28,7 @@ describe('validateSchemaDefinition', () => {
     const schema = await loadSchema({ schemaPaths: [schemaPath] });
     const configuration = new Configuration(schema);
 
-    const errors = validateSchemaDefinition(
-      schema.definition,
-      [],
-      configuration
-    );
+    const errors = validateSchemaDefinition(schema, [], configuration);
 
     assert.equal(1, errors.length);
   });
@@ -46,11 +38,7 @@ describe('validateSchemaDefinition', () => {
     const schema = await loadSchema({ schemaPaths: [schemaPath] });
     const configuration = new Configuration(schema);
 
-    const errors = validateSchemaDefinition(
-      schema.definition,
-      [],
-      configuration
-    );
+    const errors = validateSchemaDefinition(schema, [], configuration);
 
     assert.equal(1, errors.length);
   });
@@ -60,11 +48,7 @@ describe('validateSchemaDefinition', () => {
     const schema = await loadSchema({ schemaPaths: [schemaPath] });
     const configuration = new Configuration(schema);
 
-    const errors = validateSchemaDefinition(
-      schema.definition,
-      [],
-      configuration
-    );
+    const errors = validateSchemaDefinition(schema, [], configuration);
 
     assert.equal(2, errors.length);
 
@@ -80,11 +64,7 @@ describe('validateSchemaDefinition', () => {
     const schema = await loadSchema({ schemaPaths: [schemaPath] });
     const configuration = new Configuration(schema);
 
-    const errors = validateSchemaDefinition(
-      schema.definition,
-      [],
-      configuration
-    );
+    const errors = validateSchemaDefinition(schema, [], configuration);
 
     assert.equal(1, errors.length);
 
@@ -106,13 +86,13 @@ describe('validateSchemaDefinition', () => {
       return {};
     };
 
-    const ruleWithoutConfiguration = context => {
+    const ruleWithoutConfiguration = (context) => {
       assert.equal('ValidationContext', context.constructor.name);
       return {};
     };
 
     const errors = validateSchemaDefinition(
-      schema.definition,
+      schema,
       [ruleWithConfiguration, ruleWithoutConfiguration],
       configuration
     );
@@ -124,7 +104,7 @@ describe('validateSchemaDefinition', () => {
 function DummyValidator(context) {
   return {
     Document: {
-      leave: node => {
+      leave: (node) => {
         context.reportError(new GraphQLError('Dummy message', [node]));
       },
     },


### PR DESCRIPTION
This PR introduces the ability to disable and re-enable blocks in schema files using GraphQL comment syntax, as well as disabling rules for a single line.

Syntax is as follows:
```graphql
# lint-disable fields-have-descriptions, fields-are-camel-cased
type Comment {
  id: ID!
  message: String!
  author: User!
}
# lint-enable fields-have-descriptions, fields-are-camel-cased

type User {
  id: ID! #lint-disable-line fields-have-descriptions
  name: String!
}
```

These linter comments are file-specific, so if you have a multi-file schema they will only apply to the file where they are included.

Closes #18 