### PR TITLE
Add an ignore list to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Options:
 
     example: --rules fields-have-descriptions,types-have-descriptions
 
+  -i, --ignore <ignore list>
+
+    ignore errors in specific entries
+
+    example: --ignore "{'fields-have-descriptions':['Obvious','Query.obvious','Query.something.obvious']}"
+
   -f, --format <format>
 
     choose the output format of the report

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -10,6 +10,7 @@ export class Configuration {
     options:
       - format: (required) `text` | `json`
       - rules: [string array] whitelist rules
+      - ignore: [string to string array object] ignore list for rules. Example: {'fields-have-descriptions': ['Obvious', 'Query.obvious', 'Query.something.obvious']}
       - customRulePaths: [string array] path to additional custom rules to be loaded
       - commentDescriptions: [boolean] use old way of defining descriptions in GraphQL SDL
       - oldImplementsSyntax: [boolean] use old way of defining implemented interfaces in GraphQL SDL
@@ -20,6 +21,7 @@ export class Configuration {
       customRulePaths: [],
       commentDescriptions: false,
       oldImplementsSyntax: false,
+      ignore: {},
     };
 
     this.schema = schema;
@@ -61,7 +63,7 @@ export class Configuration {
     let specifiedRules;
     if (this.options.rules && this.options.rules.length > 0) {
       specifiedRules = this.options.rules.map(toUpperCamelCase);
-      rules = this.getAllRules().filter(rule => {
+      rules = this.getAllRules().filter((rule) => {
         return specifiedRules.indexOf(rule.name) >= 0;
       });
     }
@@ -69,7 +71,7 @@ export class Configuration {
     // DEPRECATED - This code should be removed in v1.0.0.
     if (this.options.only && this.options.only.length > 0) {
       specifiedRules = this.options.only.map(toUpperCamelCase);
-      rules = this.getAllRules().filter(rule => {
+      rules = this.getAllRules().filter((rule) => {
         return specifiedRules.indexOf(rule.name) >= 0;
       });
     }
@@ -77,7 +79,7 @@ export class Configuration {
     // DEPRECATED - This code should be removed in v1.0.0.
     if (this.options.except && this.options.except.length > 0) {
       specifiedRules = this.options.except.map(toUpperCamelCase);
-      rules = this.getAllRules().filter(rule => {
+      rules = this.getAllRules().filter((rule) => {
         return specifiedRules.indexOf(rule.name) == -1;
       });
     }
@@ -99,9 +101,9 @@ export class Configuration {
     const expandedPaths = expandPaths(rulePaths);
     const rules = new Set([]);
 
-    expandedPaths.map(rulePath => {
+    expandedPaths.map((rulePath) => {
       let ruleMap = require(rulePath);
-      Object.keys(ruleMap).forEach(k => rules.add(ruleMap[k]));
+      Object.keys(ruleMap).forEach((k) => rules.add(ruleMap[k]));
     });
 
     return Array.from(rules);
@@ -109,6 +111,10 @@ export class Configuration {
 
   getAllBuiltInRules() {
     return this.getRulesFromPaths([this.builtInRulePaths]);
+  }
+
+  getIgnoreList() {
+    return this.options.ignore;
   }
 
   validate() {
@@ -134,7 +140,7 @@ export class Configuration {
       }
     }
 
-    const ruleNames = rules.map(rule => rule.name);
+    const ruleNames = rules.map((rule) => rule.name);
 
     let misConfiguredRuleNames = []
       .concat(
@@ -143,7 +149,7 @@ export class Configuration {
         this.options.rules || []
       )
       .map(toUpperCamelCase)
-      .filter(name => ruleNames.indexOf(name) == -1);
+      .filter((name) => ruleNames.indexOf(name) == -1);
 
     if (this.getFormatter() == null) {
       issues.push({
@@ -170,6 +176,6 @@ export class Configuration {
 function toUpperCamelCase(string) {
   return string
     .split('-')
-    .map(part => part[0].toUpperCase() + part.slice(1))
+    .map((part) => part[0].toUpperCase() + part.slice(1))
     .join('');
 }

--- a/src/find_schema_nodes.js
+++ b/src/find_schema_nodes.js
@@ -4,7 +4,7 @@ import { visit } from 'graphql';
   scopes: (required) string array
   schema: (required) GraphQLSchema
 
-  A scope could be a `Type`, `Type.field` or `Type.field.argument`.
+  A scope could be a `Type`, `Type.field`, `Type.field.argument` or `Enum.VALUE`.
 */
 export function findSchemaNodes(scopes, schema) {
   const result = new Set();
@@ -29,7 +29,10 @@ function findScopeNode(scope, schema) {
     return astNode;
   }
 
-  const field = type?.getFields()[fieldName];
+  const field =
+    astNode?.kind === 'EnumTypeDefinition'
+      ? type?.getValue(fieldName)
+      : type?.getFields()[fieldName];
   astNode = field?.astNode;
   if (argumentName === undefined) {
     return astNode;

--- a/src/find_schema_nodes.js
+++ b/src/find_schema_nodes.js
@@ -1,7 +1,7 @@
 import { visit } from 'graphql';
 
 /*
-  scopes: (requried) string | string array
+  scopes: (requried) string array
   schema: (required) GraphQLSchema
 
   A scope could be a `Type`, `Type.field` or `Type.field.argument`.

--- a/src/find_schema_nodes.js
+++ b/src/find_schema_nodes.js
@@ -1,7 +1,7 @@
 import { visit } from 'graphql';
 
 /*
-  scopes: (requried) string array
+  scopes: (required) string array
   schema: (required) GraphQLSchema
 
   A scope could be a `Type`, `Type.field` or `Type.field.argument`.

--- a/src/find_schema_nodes.js
+++ b/src/find_schema_nodes.js
@@ -1,0 +1,41 @@
+import { visit } from 'graphql';
+
+/*
+  scopes: (requried) string | string array
+  schema: (required) GraphQLSchema
+
+  A scope could be a `Type`, `Type.field` or `Type.field.argument`.
+*/
+export function findSchemaNodes(scopes, schema) {
+  const result = new Set();
+  const tracer = {
+    enter: (node) => {
+      result.add(node);
+    },
+    leave: () => {},
+  };
+  for (const scope of scopes) {
+    const node = findScopeNode(scope, schema);
+    node && visit(node, tracer);
+  }
+  return result;
+}
+
+function findScopeNode(scope, schema) {
+  const [typeName, fieldName, argumentName] = scope.split('.');
+  const type = schema.getType(typeName);
+  let astNode = type?.astNode;
+  if (fieldName === undefined) {
+    return astNode;
+  }
+
+  const field = type?.getFields()[fieldName];
+  astNode = field?.astNode;
+  if (argumentName === undefined) {
+    return astNode;
+  }
+
+  const argument = field?.args.find((arg) => arg.name === argumentName);
+  astNode = argument?.astNode;
+  return astNode;
+}

--- a/src/options.js
+++ b/src/options.js
@@ -15,20 +15,21 @@ export function loadOptionsFromConfigDir(configDirectory) {
 
     // If schemaPaths come from cosmic, we resolve the given paths relative to the searchPath.
     if (cosmic.config.schemaPaths) {
-      schemaPaths = cosmic.config.schemaPaths.map(schemaPath =>
+      schemaPaths = cosmic.config.schemaPaths.map((schemaPath) =>
         path.resolve(searchPath, schemaPath)
       );
     }
 
     // If customRulePaths come from cosmic, we resolve the given paths relative to the searchPath.
     if (cosmic.config.customRulePaths) {
-      customRulePaths = cosmic.config.customRulePaths.map(schemaPath =>
+      customRulePaths = cosmic.config.customRulePaths.map((schemaPath) =>
         path.resolve(searchPath, schemaPath)
       );
     }
 
     return {
       rules: cosmic.config.rules,
+      ignore: cosmic.config.ignore,
       customRulePaths: customRulePaths || [],
       schemaPaths: schemaPaths,
     };

--- a/src/runner.js
+++ b/src/runner.js
@@ -15,6 +15,10 @@ export async function run(stdout, stdin, stderr, argv) {
       'only the rules specified will be used to validate the schema. Example: fields-have-descriptions,types-have-descriptions'
     )
     .option(
+      '-i, --ignore <ignore list>',
+      "ignore errors for specific subjects. Example: {'fields-have-descriptions':['Obvious','Query.obvious','Query.something.obvious']}"
+    )
+    .option(
       '-f, --format <format>',
       'choose the output format of the report. Possible values: json, text, compact'
     )
@@ -146,6 +150,10 @@ function getOptionsFromCommander(commander) {
 
   if (commander.rules) {
     options.rules = commander.rules.split(',');
+  }
+
+  if (commander.ignore) {
+    options.ignore = JSON.parse(commander.ignore);
   }
 
   if (commander.customRulePaths) {

--- a/src/validator.js
+++ b/src/validator.js
@@ -150,7 +150,8 @@ function ignoreListErrorFilter(schema, configuration) {
   return (error) => {
     if (error instanceof ValidationError) {
       const subjects = index[error.ruleName];
-      return subjects === undefined || !subjects.has(error.nodes[0]);
+      const ignore = subjects?.has(error.nodes[0]);
+      return !ignore;
     } else {
       return true;
     }

--- a/test/config/js_file/graphql-schema-linter.config.js
+++ b/test/config/js_file/graphql-schema-linter.config.js
@@ -1,4 +1,11 @@
 module.exports = {
   rules: ['enum-values-sorted-alphabetically', 'enum-name-cannot-contain-enum'],
+  ignore: {
+    'fields-have-descriptions': [
+      'Obvious',
+      'Query.obvious',
+      'Query.something.obvious',
+    ],
+  },
   customRulePaths: [`${__dirname}/../../fixtures/custom_rules/*.js`],
 };

--- a/test/config/js_file/test.js
+++ b/test/config/js_file/test.js
@@ -14,13 +14,30 @@ describe('Config', () => {
       assert.equal(rules.length, 2);
       assert.equal(
         2,
-        rules.filter(rule => {
+        rules.filter((rule) => {
           return (
             rule.name == 'EnumValuesSortedAlphabetically' ||
             rule.name == 'EnumNameCannotContainEnum'
           );
         }).length
       );
+    });
+  });
+
+  describe('getIgnoreList', () => {
+    it('pulls ignore list from a *.config.js', () => {
+      const options = loadOptionsFromConfigDir(__dirname);
+      const configuration = new Configuration(emptySchema, options);
+
+      const ignoreList = configuration.getIgnoreList();
+
+      assert.deepEqual(ignoreList, {
+        'fields-have-descriptions': [
+          'Obvious',
+          'Query.obvious',
+          'Query.something.obvious',
+        ],
+      });
     });
   });
 });

--- a/test/config/package_json/test.js
+++ b/test/config/package_json/test.js
@@ -21,10 +21,37 @@ describe('Config', () => {
       assert.equal(1, rules.length);
       assert.equal(
         1,
-        rules.filter(rule => {
+        rules.filter((rule) => {
           return rule.name == 'EnumValuesSortedAlphabetically';
         }).length
       );
+    });
+  });
+
+  describe('getIgnoreList', () => {
+    it('pulls ignore list from the package.json file', () => {
+      const options = loadOptionsFromConfigDir(
+        temporaryConfigDirectory({
+          ignore: {
+            'fields-have-descriptions': [
+              'Obvious',
+              'Query.obvious',
+              'Query.something.obvious',
+            ],
+          },
+        })
+      );
+      const configuration = new Configuration(emptySchema, options);
+
+      const ignoreList = configuration.getIgnoreList();
+
+      assert.deepEqual(ignoreList, {
+        'fields-have-descriptions': [
+          'Obvious',
+          'Query.obvious',
+          'Query.something.obvious',
+        ],
+      });
     });
   });
 

--- a/test/config/rc_file/.graphql-schema-linterrc
+++ b/test/config/rc_file/.graphql-schema-linterrc
@@ -1,3 +1,4 @@
 {
-  "rules": ["enum-values-sorted-alphabetically"]
+  "rules": ["enum-values-sorted-alphabetically"],
+  "ignore": {"fields-have-descriptions": ["Obvious", "Query.obvious", "Query.something.obvious"]},
 }

--- a/test/config/rc_file/test.js
+++ b/test/config/rc_file/test.js
@@ -14,10 +14,27 @@ describe('Config', () => {
       assert.equal(rules.length, 1);
       assert.equal(
         1,
-        rules.filter(rule => {
+        rules.filter((rule) => {
           return rule.name == 'EnumValuesSortedAlphabetically';
         }).length
       );
+    });
+  });
+
+  describe('getIgnoreList', () => {
+    it('pulls ignore list from a .graphql-schema-linterrc dotfile', () => {
+      const options = loadOptionsFromConfigDir(__dirname);
+      const configuration = new Configuration(emptySchema, options);
+
+      const ignoreList = configuration.getIgnoreList();
+
+      assert.deepEqual(ignoreList, {
+        'fields-have-descriptions': [
+          'Obvious',
+          'Query.obvious',
+          'Query.something.obvious',
+        ],
+      });
     });
   });
 });

--- a/test/find_schema_nodes.js
+++ b/test/find_schema_nodes.js
@@ -1,0 +1,84 @@
+import assert from 'assert';
+import { parse } from 'graphql';
+import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
+import { findSchemaNodes } from '../src/find_schema_nodes';
+
+describe('findSchemaNodes', () => {
+  it('works', () => {
+    const ast = parse(`
+      type Query {
+        foo: Foo!
+        fizz: Fizz
+        blem: Blem
+      }
+
+      scalar Blem
+
+      interface Fizz {
+        buzz(buzzFizz: String!, fizzBuzz: Int): Int
+      }
+
+      type Foo {
+        bar(blem: Int!): String
+      }
+    `);
+
+    const schema = buildASTSchema(ast, {
+      commentDescriptions: false,
+      assumeValidSDL: true,
+      assumeValid: true,
+    });
+
+    // Helper method is used because the output is too noisy
+    // with all those aux AST nodes like Name and NotNullType
+    const test = ({ scopes, expected }) => {
+      assert.deepEqual(findFiltered(scopes), expected);
+    };
+
+    const findFiltered = (scopes) => {
+      const raw = findSchemaNodes(scopes, schema);
+      const filtered = [];
+      for (const node of raw) {
+        if (node.kind.endsWith('Definition')) {
+          filtered.push(`${node.kind} : ${node.name.value}`);
+        }
+      }
+      filtered.sort();
+      return filtered;
+    };
+
+    test({
+      scopes: ['Query'],
+      expected: [
+        'FieldDefinition : blem',
+        'FieldDefinition : fizz',
+        'FieldDefinition : foo',
+        'ObjectTypeDefinition : Query',
+      ],
+    });
+
+    test({
+      scopes: ['Query.foo', 'Query.blem'],
+      expected: ['FieldDefinition : blem', 'FieldDefinition : foo'],
+    });
+
+    test({
+      scopes: ['Blem'],
+      expected: ['ScalarTypeDefinition : Blem'],
+    });
+
+    test({
+      scopes: ['Fizz.buzz'],
+      expected: [
+        'FieldDefinition : buzz',
+        'InputValueDefinition : buzzFizz',
+        'InputValueDefinition : fizzBuzz',
+      ],
+    });
+
+    test({
+      scopes: ['Fizz.buzz.fizzBuzz'],
+      expected: ['InputValueDefinition : fizzBuzz'],
+    });
+  });
+});

--- a/test/find_schema_nodes.js
+++ b/test/find_schema_nodes.js
@@ -4,49 +4,7 @@ import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 import { findSchemaNodes } from '../src/find_schema_nodes';
 
 describe('findSchemaNodes', () => {
-  it('works', () => {
-    const ast = parse(`
-      type Query {
-        foo: Foo!
-        fizz: Fizz
-        blem: Blem
-      }
-
-      scalar Blem
-
-      interface Fizz {
-        buzz(buzzFizz: String!, fizzBuzz: Int): Int
-      }
-
-      type Foo {
-        bar(blem: Int!): String
-      }
-    `);
-
-    const schema = buildASTSchema(ast, {
-      commentDescriptions: false,
-      assumeValidSDL: true,
-      assumeValid: true,
-    });
-
-    // Helper method is used because the output is too noisy
-    // with all those aux AST nodes like Name and NotNullType
-    const test = ({ scopes, expected }) => {
-      assert.deepEqual(findFiltered(scopes), expected);
-    };
-
-    const findFiltered = (scopes) => {
-      const raw = findSchemaNodes(scopes, schema);
-      const filtered = [];
-      for (const node of raw) {
-        if (node.kind.endsWith('Definition')) {
-          filtered.push(`${node.kind} : ${node.name.value}`);
-        }
-      }
-      filtered.sort();
-      return filtered;
-    };
-
+  it('returns relevant AST nodes given object as a scope', () => {
     test({
       scopes: ['Query'],
       expected: [
@@ -56,17 +14,9 @@ describe('findSchemaNodes', () => {
         'ObjectTypeDefinition : Query',
       ],
     });
+  });
 
-    test({
-      scopes: ['Query.foo', 'Query.blem'],
-      expected: ['FieldDefinition : blem', 'FieldDefinition : foo'],
-    });
-
-    test({
-      scopes: ['Blem'],
-      expected: ['ScalarTypeDefinition : Blem'],
-    });
-
+  it('returns relevant AST nodes given field as a scope', () => {
     test({
       scopes: ['Fizz.buzz'],
       expected: [
@@ -75,10 +25,139 @@ describe('findSchemaNodes', () => {
         'InputValueDefinition : fizzBuzz',
       ],
     });
+  });
 
+  it('returns combined list of AST nodes given multiple scopes', () => {
+    test({
+      scopes: ['Query.foo', 'Query.blem'],
+      expected: ['FieldDefinition : blem', 'FieldDefinition : foo'],
+    });
+  });
+
+  it('returns relevant AST nodes given parameter as a scope', () => {
     test({
       scopes: ['Fizz.buzz.fizzBuzz'],
       expected: ['InputValueDefinition : fizzBuzz'],
     });
   });
+
+  it('returns relevant AST nodes given scalar type as a scope', () => {
+    test({
+      scopes: ['Blem'],
+      expected: ['ScalarTypeDefinition : Blem'],
+    });
+  });
+
+  it('returns relevant AST nodes given enum as a scope', () => {
+    test({
+      scopes: ['Episode'],
+      expected: [
+        'EnumTypeDefinition : Episode',
+        'EnumValueDefinition : EMPIRE',
+        'EnumValueDefinition : JEDI',
+        'EnumValueDefinition : NEWHOPE',
+      ],
+    });
+  });
+
+  it('returns relevant AST nodes given enum value as a scope', () => {
+    test({
+      scopes: ['Episode.NEWHOPE'],
+      expected: ['EnumValueDefinition : NEWHOPE'],
+    });
+  });
+
+  it('returns relevant AST nodes given input type as a scope', () => {
+    test({
+      scopes: ['ReviewInput'],
+      expected: [
+        'InputObjectTypeDefinition : ReviewInput',
+        'InputValueDefinition : commentary',
+        'InputValueDefinition : stars',
+      ],
+    });
+  });
+
+  it('returns relevant AST nodes given input type field as a scope', () => {
+    test({
+      scopes: ['ReviewInput.commentary'],
+      expected: ['InputValueDefinition : commentary'],
+    });
+  });
+
+  it('returns relevant AST nodes given interface as a scope', () => {
+    test({
+      scopes: ['Character'],
+      expected: [
+        'FieldDefinition : id',
+        'FieldDefinition : name',
+        'InterfaceTypeDefinition : Character',
+      ],
+    });
+  });
+
+  it('returns relevant AST nodes given interface field as a scope', () => {
+    test({
+      scopes: ['Character.name'],
+      expected: ['FieldDefinition : name'],
+    });
+  });
+
+  const ast = parse(`
+    type Query {
+      foo: Foo!
+      fizz: Fizz
+      blem: Blem
+    }
+
+    scalar Blem
+
+    interface Fizz {
+      buzz(buzzFizz: String!, fizzBuzz: Int): Int
+    }
+
+    type Foo {
+      bar(blem: Int!): String
+    }
+
+    enum Episode {
+      NEWHOPE
+      EMPIRE
+      JEDI
+    }
+
+    input ReviewInput {
+      stars: Int!
+      commentary: String
+    }
+
+    interface Character {
+      id: ID!
+      name: String!
+    }
+  `);
+
+  const schema = buildASTSchema(ast, {
+    commentDescriptions: false,
+    assumeValidSDL: true,
+    assumeValid: true,
+  });
+
+  // Helper method is used because the output is too noisy
+  // with all those aux AST nodes like Name and NotNullType
+  const test = ({ scopes, expected }) => {
+    assert.deepEqual(findFiltered(scopes), expected);
+  };
+
+  const findFiltered = (scopes) => {
+    const raw = findSchemaNodes(scopes, schema);
+    const filtered = [];
+    for (const node of raw) {
+      if (node.kind.endsWith('Definition')) {
+        filtered.push(`${node.kind} : ${node.name.value}`);
+      }
+    }
+    filtered.sort();
+    return filtered;
+  };
 });

--- a/test/find_schema_nodes.js
+++ b/test/find_schema_nodes.js
@@ -103,6 +103,13 @@ describe('findSchemaNodes', () => {
     });
   });
 
+  it('returns relevant AST nodes given union as a scope', () => {
+    test({
+      scopes: ['SomeUnion'],
+      expected: ['UnionTypeDefinition : SomeUnion'],
+    });
+  });
+
   const ast = parse(`
     type Query {
       foo: Foo!
@@ -135,6 +142,8 @@ describe('findSchemaNodes', () => {
       id: ID!
       name: String!
     }
+
+    union SomeUnion = Fizz | Foo
   `);
 
   const schema = buildASTSchema(ast, {

--- a/test/fixtures/schema/obvious.graphql
+++ b/test/fixtures/schema/obvious.graphql
@@ -1,0 +1,8 @@
+type Obvious {
+  one: String!
+  two: Int
+}
+
+type DontPanic {
+  obvious: Boolean
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -21,17 +21,18 @@ const getRelocatedPath = (dir, fullPath) => {
 
 export const temporaryConfigDirectory = ({
   rules = null,
+  ignore = null,
   customRulePaths = [],
   schemaPaths = [],
 }) => {
   const configDirectory = mkdtempSync(path.join(os.tmpdir(), TEMP_DIR_PREFIX));
   let fixCustomRulePaths = [];
   let fixedSchemaPaths = [];
-  const options = { rules };
+  const options = { rules, ignore };
 
   // due to the temp nature of the directory creation we ought to fix the provided paths to match the location.
   if (customRulePaths.length) {
-    fixCustomRulePaths = customRulePaths.map(rulePath =>
+    fixCustomRulePaths = customRulePaths.map((rulePath) =>
       getRelocatedPath(configDirectory, rulePath)
     );
 
@@ -39,7 +40,7 @@ export const temporaryConfigDirectory = ({
   }
 
   if (schemaPaths.length) {
-    fixedSchemaPaths = schemaPaths.map(globPath =>
+    fixedSchemaPaths = schemaPaths.map((globPath) =>
       getRelocatedPath(configDirectory, globPath)
     );
 

--- a/test/index.js
+++ b/test/index.js
@@ -9,6 +9,7 @@ require('./schema');
 require('./source_map');
 require('./validator');
 require('./inline_configuration');
+require('./find_schema_nodes');
 require('./rules/arguments_have_descriptions');
 require('./rules/defined_types_are_used');
 require('./rules/deprecations_have_a_reason');

--- a/test/runner.js
+++ b/test/runner.js
@@ -262,6 +262,8 @@ describe('Runner', () => {
         'json',
         '--rules',
         'fields-have-descriptions',
+        '--ignore',
+        '{"fields-have-descriptions": ["Obvious", "DontPanic.obvious"]}',
         `${__dirname}/fixtures/schema/*.graphql`,
       ];
 

--- a/test/schema.js
+++ b/test/schema.js
@@ -25,6 +25,15 @@ type Post {
   author: User!
 }
 
+type Obvious {
+  one: String!
+  two: Int
+}
+
+type DontPanic {
+  obvious: Boolean
+}
+
 type Query {
   something: String!
 }

--- a/test/validator.js
+++ b/test/validator.js
@@ -9,7 +9,10 @@ describe('validateSchemaDefinition', () => {
   it('returns errors sorted by line number', async () => {
     const schemaPath = `${__dirname}/fixtures/schema/**/*.graphql`;
     const schema = await loadSchema({ schemaPaths: [schemaPath] });
-    const configuration = new Configuration(schema);
+    const options = {
+      ignore: { 'fields-have-descriptions': ['Obvious', 'DontPanic.obvious'] },
+    };
+    const configuration = new Configuration(schema, options);
 
     const rules = [FieldsHaveDescriptions, DummyValidator];
 


### PR DESCRIPTION
It allows to ignore errors about specific rules raised by specific subjects.
Difference with [similar feature](https://github.com/cjoudrey/graphql-schema-linter/pull/237) is that now ignore list comes from the config or command line.

Subject could be specified as
* `Type`
* `Type.field`
* `Type.field.argument`

**NOTE** subjects are scopes, so for example if you ignore some type - errors from all of the sub-nodes (fields, their arguments and so on) would be ignored too.

```json
{
  "rules": ["enum-values-sorted-alphabetically"],
  "ignore": {"fields-have-descriptions": ["Obvious", "Query.obvious", "Query.something.obvious"]},
}
```
```
--ignore "{'fields-have-descriptions': ['Obvious', 'Query.obvious', 'Query.something.obvious']}"
```