### PR TITLE
use peer deps for graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,14 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
+    "graphql": "^15.3.0",
     "husky": "4.2.5",
     "lint-staged": "10.1.3",
     "mocha": "8.0.1",
     "prettier": "2.0.5"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0"
   },
   "babel": {
     "presets": [
@@ -44,8 +48,7 @@
     "columnify": "^1.5.4",
     "commander": "^3.0.0",
     "cosmiconfig": "^5.2.1",
-    "glob": "^7.1.2",
-    "graphql": "^15.0.0"
+    "glob": "^7.1.2"
   },
   "bin": {
     "graphql-schema-linter": "lib/cli.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@ graceful-fs@^4.1.11:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-graphql@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.0.0.tgz#042a5eb5e2506a2e2111ce41eb446a8e570b8be9"
-  integrity sha512-ZyVO1xIF9F+4cxfkdhOJINM+51B06Friuv4M66W7HzUOeFd+vNzUn4vtswYINPi6sysjf1M2Ri/rwZALqgwbaQ==
+graphql@^15.3.0:
+  version "15.3.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
 
 growl@1.10.5:
   version "1.10.5"


### PR DESCRIPTION
This PR moves `graphql` to a devDep for internal usage, and a peerDep for consumers. It is necessary because some graphql tools will not work if there are multiple versions of graphql installed.