### PR TITLE
Fixes the bug TypeError: Cannot convert undefined or null to object after adding the ignoreList

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -29,7 +29,7 @@ export function loadOptionsFromConfigDir(configDirectory) {
 
     return {
       rules: cosmic.config.rules,
-      ignore: cosmic.config.ignore,
+      ignore: cosmic.config.ignore || {},
       customRulePaths: customRulePaths || [],
       schemaPaths: schemaPaths,
     };


### PR DESCRIPTION
Fixes #250 

## Description
This PR fixes the error being thrown as **TypeError: Cannot convert undefined or null to object**. This is happening after we introduced the ignorelist. It's easily reproducible when we have a config file and the config file looks like this:
![image](https://user-images.githubusercontent.com/8287937/92823782-87ed5f00-f382-11ea-8dc3-8d7e0754386e.png)

It does not have the config value passed.
Note: This is not reproducible in case of running the graphql-schema-linter from the command line.