### PR TITLE
Sort enum values by localeCompare()

### DIFF
--- a/src/util/listIsAlphabetical.js
+++ b/src/util/listIsAlphabetical.js
@@ -15,7 +15,7 @@ function arraysEqual(a, b) {
  * @return {Object} { isSorted: Bool, sortedList: String[] }
  */
 export default function listIsAlphabetical(list) {
-  const sortedList = list.slice().sort();
+  const sortedList = list.slice().sort((a, b) => a.localeCompare(b));
   return {
     isSorted: arraysEqual(list, sortedList),
     sortedList,

--- a/test/rules/enum_values_sorted_alphabetically.js
+++ b/test/rules/enum_values_sorted_alphabetically.js
@@ -32,4 +32,17 @@ describe('EnumValuesSortedAlphabetically rule', () => {
     `
     );
   });
+
+  it('sorts enum values with underscores first', () => {
+    expectPassesRule(
+      EnumValuesSortedAlphabetically,
+      `
+      enum Stage {
+        AA_
+        AAA
+        ZZZ
+      }
+    `
+    );
+  });
 });


### PR DESCRIPTION
Thanks for a great library! 💎

I am using [`lexicographicSortSchema`](https://github.com/graphql/graphql-js/blob/bbd8429b85594d9ee8cc632436e2d0f900d703ef/src/utilities/lexicographicSortSchema.js#L41) from graphql-js to sort my schema. I have an enum that has values that contain underscores. Because `lexicographicSortSchema` sorts using [`String.prototype.localeCompare()`](https://github.com/graphql/graphql-js/blob/bbd8429b85594d9ee8cc632436e2d0f900d703ef/src/utilities/lexicographicSortSchema.js#L183) the enum values with underscores (e.g., `to_do`) are sorted before the enum values with letters (e.g., `todo`). graphql-schema-linter flags this as a violation of `enum-values-sorted-alphabetically`. This PR aligns `enum-values-sorted-alphabetically` with `lexicographicSortSchema`.