### PR TITLE
Add interface-fields-sorted-alphabetically rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ This rule will validate that input object value names are camel cased.
 
 This rule will validate that input object values have a description.
 
+### `interface-fields-sorted-alphabetically`
+
+This rule will validate that all interface object fields are sorted alphabetically.
+
 ### `relay-connection-types-spec`
 
 This rule will validate the schema adheres to [section 2 (Connection Types)](https://facebook.github.io/relay/graphql/connections.htm#sec-Connection-Types) of the [Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm).

--- a/src/rules/interface_fields_sorted_alphabetically.js
+++ b/src/rules/interface_fields_sorted_alphabetically.js
@@ -1,0 +1,22 @@
+import { ValidationError } from '../validation_error';
+import listIsAlphabetical from '../util/listIsAlphabetical';
+
+export function InterfaceFieldsSortedAlphabetically(context) {
+  return {
+    InterfaceTypeDefinition(node) {
+      const fieldList = (node.fields || []).map((field) => field.name.value);
+      const { isSorted, sortedList } = listIsAlphabetical(fieldList);
+
+      if (!isSorted) {
+        context.reportError(
+          new ValidationError(
+            'interface-fields-sorted-alphabetically',
+            `The fields of interface type \`${node.name.value}\` should be sorted alphabetically. ` +
+              `Expected sorting: ${sortedList.join(', ')}`,
+            [node]
+          )
+        );
+      }
+    },
+  };
+}

--- a/test/index.js
+++ b/test/index.js
@@ -22,6 +22,7 @@ require('./rules/fields_have_descriptions');
 require('./rules/input_object_fields_sorted_alphabetically');
 require('./rules/input_object_values_are_camel_cased');
 require('./rules/input_object_values_have_descriptions');
+require('./rules/interface_fields_sorted_alphabetically');
 require('./rules/relay_connection_arguments_spec');
 require('./rules/relay_connection_types_spec');
 require('./rules/relay_page_info_spec');

--- a/test/rules/interface_fields_sorted_alphabetically.js
+++ b/test/rules/interface_fields_sorted_alphabetically.js
@@ -1,0 +1,36 @@
+import { InterfaceFieldsSortedAlphabetically } from '../../src/rules/interface_fields_sorted_alphabetically';
+import { expectFailsRule, expectPassesRule } from '../assertions';
+
+
+describe('InterfaceFieldsSortedAlphabetically rule', () => {
+  it('catches interface fields are not sorted alphabetically', () => {
+    expectFailsRule(
+      InterfaceFieldsSortedAlphabetically,
+      `
+      interface Error {
+        b: String
+        a: String
+      }
+    `,
+      [
+        {
+          message:
+            'The fields of interface type `Error` should be sorted alphabetically. Expected sorting: a, b',
+          locations: [{ line: 2, column: 7 }],
+        },
+      ]
+    );
+  });
+
+  it('allows interfaces that are sorted alphabetically ', () => {
+    expectPassesRule(
+        InterfaceFieldsSortedAlphabetically,
+      `
+      interface Error {
+        a: String
+        b: String
+      }
+    `
+    );
+  });
+});


### PR DESCRIPTION
Resolves #258 

Add additional rule `interface-fields-sorted-alphabetically` to validate A->Z order of interface fields.