### PR TITLE
Wait for stdout writing to finish before exiting

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -107,7 +107,12 @@ export async function run(stdout, stdin, stderr, argv) {
   const errors = validateSchemaDefinition(schema, rules, configuration);
   const groupedErrors = groupErrorsBySchemaFilePath(errors, schema.sourceMap);
 
-  stdout.write(formatter(groupedErrors));
+  const writeResult = stdout.write(formatter(groupedErrors));
+  if (!writeResult) {
+    await new Promise((resolve) => {
+      stdout.on('drain', () => resolve());
+    });
+  }
 
   return errors.length > 0 ? 1 : 0;
 }

--- a/test/runner.js
+++ b/test/runner.js
@@ -10,12 +10,20 @@ describe('Runner', () => {
     write: (text) => {
       stdout = stdout + text;
     },
+    on: (_eventName, callback) => {
+      const delay = Math.random() * (20 - 10) + 10;
+      setTimeout(callback, delay);
+    },
   };
 
   var stderr;
   var mockStderr = {
     write: (text) => {
       stderr = stderr + text;
+    },
+    on: (_eventName, callback) => {
+      const delay = Math.random() * (20 - 10) + 10;
+      setTimeout(callback, delay);
     },
   };
 


### PR DESCRIPTION
This fixes a race condition when writing to stdout on certain platforms and streams.

As noted in [A note on process I/O](https://nodejs.org/api/process.html#process_a_note_on_process_i_o) in the Node documentation, the `process.stdout` stream is asynchronous in some cases (pipes on POSIX, TTYs on Windows).

In these cases, the output sent to stdout can sometimes be cut off at the first chunk because the linter process exits before the stream is finished writing. The result is either a truncated set of errors (with default output) or invalid JSON (with JSON output) when the set of errors exceeds the default chunk size.

This is fixed by using the return status of `socket.write` to determine if some of the data was queued, then awaiting the socket's `'drain'` event if so before returning.