### PR TITLE
Check for `ruleName` instead of using `instanceof`

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -148,7 +148,7 @@ function ignoreListErrorFilter(schema, configuration) {
   }
 
   return (error) => {
-    if (error instanceof ValidationError) {
+    if (error.ruleName) {
       const subjects = index[error.ruleName];
       const ignore = subjects?.has(error.nodes[0]);
       return !ignore;


### PR DESCRIPTION
Custom rules written outside of `graphql-schema-linter` cannot create instances of the `ValidationError` class that's used inside `validator.js` because they have to import from their own reference to it, which is typically separate from the reference that the globally-installed `graphql-schema-linter` is using.

Instead of using an `instanceof` check (which requires the object reference to be identical), we check for the presence of `ruleName` for (mostly) equivalent behavior.

Tests are added that demonstrate and document the desired behavior.

Fixes #265.