### PR TITLE
Export ValidationError from index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 module.exports.runner = require('./runner.js');
 module.exports.validator = require('./validator.js');
 module.exports.configuration = require('./configuration.js');
+module.exports.ValidationError = require('./validation_error.js').ValidationError;


### PR DESCRIPTION
ValidationError is important parts of building custom lint rule.
I'm very glad if ValidationError become part of public api.