### PR TITLE
Add support for `graphql` v16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
 before_script:
   - yarn prepare
 script:
-  - yarn test
+  - yarn test:ci
   - node lib/cli.js --version
   - node lib/cli.js test/fixtures/valid.graphql
   - cat test/fixtures/valid.graphql | node lib/cli.js --stdin

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha test/index.js",
-    "test:ci": "yarn test && yarn test:ci:graphql-v15.x && yarn test:ci:graphql-v16.0 && yarn test:ci:graphql-v16.x",
+    "test:ci": "yarn test && yarn test:ci:graphql-v15.x && yarn test:ci:graphql-v16.x",
     "test:ci:graphql-v15.x": "yarn upgrade graphql@^15.0.0 && yarn test",
-    "test:ci:graphql-v16.0": "yarn upgrade graphql@=16.0.0 && yarn test",
     "test:ci:graphql-v16.x": "yarn upgrade graphql@^16.0.0 && yarn test",
     "prepare": "rm -rf lib/* && babel ./src --ignore test --out-dir ./lib"
   },
@@ -28,7 +27,7 @@
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
-    "graphql": "^15.0.0",
+    "graphql": "=15.0.0",
     "husky": "4.3.0",
     "lint-staged": "10.5.4",
     "mocha": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha test/index.js",
+    "test:ci": "yarn test && yarn test:ci:graphql-v15.x && yarn test:ci:graphql-v16.0 && yarn test:ci:graphql-v16.x",
+    "test:ci:graphql-v15.x": "yarn upgrade graphql@^15.0.0 && yarn test",
+    "test:ci:graphql-v16.0": "yarn upgrade graphql@=16.0.0 && yarn test",
+    "test:ci:graphql-v16.x": "yarn upgrade graphql@^16.0.0 && yarn test",
     "prepare": "rm -rf lib/* && babel ./src --ignore test --out-dir ./lib"
   },
   "pkg": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,15 @@
     "type": "git",
     "url": "git+https://github.com/cjoudrey/graphql-schema-linter.git"
   },
+  "peerDependencies": {
+    "graphql": "^15.0.0 || ^16.0.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@babel/register": "^7.9.0",
+    "graphql": "^15.0.0",
     "husky": "4.3.0",
     "lint-staged": "10.5.4",
     "mocha": "8.2.1",
@@ -44,8 +48,7 @@
     "columnify": "^1.5.4",
     "commander": "^3.0.0",
     "cosmiconfig": "^5.2.1",
-    "glob": "^7.1.2",
-    "graphql": "^15.0.0"
+    "glob": "^7.1.2"
   },
   "bin": {
     "graphql-schema-linter": "lib/cli.js"

--- a/src/rules/arguments_have_descriptions.js
+++ b/src/rules/arguments_have_descriptions.js
@@ -1,4 +1,4 @@
-import { getDescription } from 'graphql/utilities/extendSchema';
+import { getDescription } from '../util/getDescription';
 import { ValidationError } from '../validation_error';
 
 export function ArgumentsHaveDescriptions(configuration, context) {

--- a/src/rules/deprecations_have_a_reason.js
+++ b/src/rules/deprecations_have_a_reason.js
@@ -1,4 +1,3 @@
-import { getDescription } from 'graphql/utilities/buildASTSchema';
 import { ValidationError } from '../validation_error';
 
 export function DeprecationsHaveAReason(context) {

--- a/src/rules/descriptions_are_capitalized.js
+++ b/src/rules/descriptions_are_capitalized.js
@@ -1,4 +1,4 @@
-import { getDescription } from 'graphql/utilities/extendSchema';
+import { getDescription } from '../util/getDescription';
 import { ValidationError } from '../validation_error';
 
 export function DescriptionsAreCapitalized(configuration, context) {

--- a/src/rules/enum_values_have_descriptions.js
+++ b/src/rules/enum_values_have_descriptions.js
@@ -1,4 +1,4 @@
-import { getDescription } from 'graphql/utilities/extendSchema';
+import { getDescription } from '../util/getDescription';
 import { ValidationError } from '../validation_error';
 
 export function EnumValuesHaveDescriptions(configuration, context) {

--- a/src/rules/fields_have_descriptions.js
+++ b/src/rules/fields_have_descriptions.js
@@ -1,4 +1,4 @@
-import { getDescription } from 'graphql/utilities/extendSchema';
+import { getDescription } from '../util/getDescription';
 import { ValidationError } from '../validation_error';
 
 export function FieldsHaveDescriptions(configuration, context) {

--- a/src/rules/input_object_values_have_descriptions.js
+++ b/src/rules/input_object_values_have_descriptions.js
@@ -1,4 +1,4 @@
-import { getDescription } from 'graphql/utilities/extendSchema';
+import { getDescription } from '../util/getDescription';
 import { ValidationError } from '../validation_error';
 
 export function InputObjectValuesHaveDescriptions(configuration, context) {

--- a/src/rules/types_have_descriptions.js
+++ b/src/rules/types_have_descriptions.js
@@ -1,4 +1,4 @@
-import { getDescription } from 'graphql/utilities/extendSchema';
+import { getDescription } from '../util/getDescription';
 import { ValidationError } from '../validation_error';
 
 function validateTypeHasDescription(configuration, context, node, typeKind) {

--- a/src/util/getDescription.js
+++ b/src/util/getDescription.js
@@ -1,0 +1,7 @@
+import { getDescription as legacyGetDescription } from 'graphql/utilities/extendSchema';
+
+export function getDescription(node, options) {
+  return legacyGetDescription
+    ? legacyGetDescription(node, options)
+    : node.description?.value;
+}

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -73,6 +73,11 @@ function validateSchemaWithRule(rule, schemaSDL, configurationOptions) {
   const schema = new Schema(`${schemaSDL}${DefaultSchema}`, null);
   const configuration = new Configuration(schema, configurationOptions);
   const errors = validateSchemaDefinition(schema, rules, configuration);
+  const transformedErrors = errors.map((error) => ({
+    locations: error.locations,
+    message: error.message,
+    ruleName: error.ruleName,
+  }));
 
-  return errors;
+  return transformedErrors;
 }

--- a/test/rules/arguments_have_descriptions.js
+++ b/test/rules/arguments_have_descriptions.js
@@ -1,8 +1,11 @@
+import { version } from 'graphql';
 import { ArgumentsHaveDescriptions } from '../../src/rules/arguments_have_descriptions';
 import {
   expectFailsRule,
   expectPassesRuleWithConfiguration,
 } from '../assertions';
+
+const itPotentially = version.startsWith('15.') ? it : it.skip;
 
 describe('ArgumentsHaveDescriptions rule', () => {
   it('catches field arguments that have no description', () => {
@@ -50,10 +53,12 @@ describe('ArgumentsHaveDescriptions rule', () => {
     );
   });
 
-  it('gets descriptions correctly with commentDescriptions option', () => {
-    expectPassesRuleWithConfiguration(
-      ArgumentsHaveDescriptions,
-      `
+  itPotentially(
+    'gets descriptions correctly with commentDescriptions option',
+    () => {
+      expectPassesRuleWithConfiguration(
+        ArgumentsHaveDescriptions,
+        `
       type Box {
         widget(
           "Widget ID"
@@ -64,7 +69,8 @@ describe('ArgumentsHaveDescriptions rule', () => {
         ): String!
       }
     `,
-      { commentDescriptions: true }
-    );
-  });
+        { commentDescriptions: true }
+      );
+    }
+  );
 });

--- a/test/rules/descriptions_are_capitalized.js
+++ b/test/rules/descriptions_are_capitalized.js
@@ -1,9 +1,12 @@
+import { version } from 'graphql';
 import { DescriptionsAreCapitalized } from '../../src/rules/descriptions_are_capitalized';
 import {
   expectFailsRule,
   expectFailsRuleWithConfiguration,
   expectPassesRule,
 } from '../assertions';
+
+const itPotentially = version.startsWith('15.') ? it : it.skip;
 
 describe('DescriptionsAreCapitalized rule', () => {
   it('detects lowercase field descriptions', () => {
@@ -28,10 +31,12 @@ describe('DescriptionsAreCapitalized rule', () => {
     );
   });
 
-  it('detects lowercase field descriptions with commentDescriptions option', () => {
-    expectFailsRuleWithConfiguration(
-      DescriptionsAreCapitalized,
-      `
+  itPotentially(
+    'detects lowercase field descriptions with commentDescriptions option',
+    () => {
+      expectFailsRuleWithConfiguration(
+        DescriptionsAreCapitalized,
+        `
       type Widget {
         # widget name
         name: String!
@@ -40,16 +45,17 @@ describe('DescriptionsAreCapitalized rule', () => {
         other: Int
       }
     `,
-      { commentDescriptions: true },
-      [
-        {
-          message:
-            'The description for field `Widget.name` should be capitalized.',
-          locations: [{ line: 4, column: 9 }],
-        },
-      ]
-    );
-  });
+        { commentDescriptions: true },
+        [
+          {
+            message:
+              'The description for field `Widget.name` should be capitalized.',
+            locations: [{ line: 4, column: 9 }],
+          },
+        ]
+      );
+    }
+  );
 
   it('does not err on an empty description', () => {
     expectPassesRule(

--- a/test/rules/enum_values_have_descriptions.js
+++ b/test/rules/enum_values_have_descriptions.js
@@ -1,8 +1,11 @@
+import { version } from 'graphql';
 import { EnumValuesHaveDescriptions } from '../../src/rules/enum_values_have_descriptions';
 import {
   expectFailsRule,
   expectPassesRuleWithConfiguration,
 } from '../assertions';
+
+const itPotentially = version.startsWith('15.') ? it : it.skip;
 
 describe('EnumValuesHaveDescriptions rule', () => {
   it('catches enum values that have no description', () => {
@@ -32,16 +35,19 @@ describe('EnumValuesHaveDescriptions rule', () => {
     );
   });
 
-  it('get descriptions correctly with commentDescriptions option', () => {
-    expectPassesRuleWithConfiguration(
-      EnumValuesHaveDescriptions,
-      `
+  itPotentially(
+    'get descriptions correctly with commentDescriptions option',
+    () => {
+      expectPassesRuleWithConfiguration(
+        EnumValuesHaveDescriptions,
+        `
       enum Status {
         # Hidden
         HIDDEN
       }
     `,
-      { commentDescriptions: true }
-    );
-  });
+        { commentDescriptions: true }
+      );
+    }
+  );
 });

--- a/test/rules/fields_have_descriptions.js
+++ b/test/rules/fields_have_descriptions.js
@@ -1,8 +1,11 @@
+import { version } from 'graphql';
 import { FieldsHaveDescriptions } from '../../src/rules/fields_have_descriptions';
 import {
   expectFailsRule,
   expectPassesRuleWithConfiguration,
 } from '../assertions';
+
+const itPotentially = version.startsWith('15.') ? it : it.skip;
 
 describe('FieldsHaveDescriptions rule', () => {
   it('catches fields that have no description', () => {
@@ -31,16 +34,19 @@ describe('FieldsHaveDescriptions rule', () => {
     );
   });
 
-  it('gets descriptions correctly with commentDescriptions option', () => {
-    expectPassesRuleWithConfiguration(
-      FieldsHaveDescriptions,
-      `
+  itPotentially(
+    'gets descriptions correctly with commentDescriptions option',
+    () => {
+      expectPassesRuleWithConfiguration(
+        FieldsHaveDescriptions,
+        `
       type A {
         "Description"
         withDescription: String
       }
     `,
-      { commentDescriptions: true }
-    );
-  });
+        { commentDescriptions: true }
+      );
+    }
+  );
 });

--- a/test/rules/input_object_values_have_descriptions.js
+++ b/test/rules/input_object_values_have_descriptions.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { parse } from 'graphql';
+import { version, parse } from 'graphql';
 import { validate } from 'graphql/validation';
 import { buildASTSchema } from 'graphql/utilities/buildASTSchema';
 
@@ -9,6 +9,8 @@ import {
   expectPassesRule,
   expectPassesRuleWithConfiguration,
 } from '../assertions';
+
+const itPotentially = version.startsWith('15.') ? it : it.skip;
 
 describe('InputObjectValuesHaveDescriptions rule', () => {
   it('catches input object type values that have no description', () => {
@@ -42,16 +44,19 @@ describe('InputObjectValuesHaveDescriptions rule', () => {
     );
   });
 
-  it('gets descriptions correctly with commentDescriptions option', () => {
-    expectPassesRuleWithConfiguration(
-      InputObjectValuesHaveDescriptions,
-      `
+  itPotentially(
+    'gets descriptions correctly with commentDescriptions option',
+    () => {
+      expectPassesRuleWithConfiguration(
+        InputObjectValuesHaveDescriptions,
+        `
       input F {
         # F
         f: String
       }
     `,
-      { commentDescriptions: true }
-    );
-  });
+        { commentDescriptions: true }
+      );
+    }
+  );
 });

--- a/test/rules/types_have_descriptions.js
+++ b/test/rules/types_have_descriptions.js
@@ -1,9 +1,12 @@
+import { version } from 'graphql';
 import { TypesHaveDescriptions } from '../../src/rules/types_have_descriptions';
 import {
   expectFailsRule,
   expectPassesRule,
   expectPassesRuleWithConfiguration,
 } from '../assertions';
+
+const itPotentially = version.startsWith('15.') ? it : it.skip;
 
 describe('TypesHaveDescriptions rule', () => {
   it('catches enum types that have no description', () => {
@@ -162,10 +165,12 @@ describe('TypesHaveDescriptions rule', () => {
     );
   });
 
-  it('gets descriptions correctly with commentDescriptions option', () => {
-    expectPassesRuleWithConfiguration(
-      TypesHaveDescriptions,
-      `
+  itPotentially(
+    'gets descriptions correctly with commentDescriptions option',
+    () => {
+      expectPassesRuleWithConfiguration(
+        TypesHaveDescriptions,
+        `
       # A
       scalar A
 
@@ -192,7 +197,8 @@ describe('TypesHaveDescriptions rule', () => {
         f: String
       }
     `,
-      { commentDescriptions: true }
-    );
-  });
+        { commentDescriptions: true }
+      );
+    }
+  );
 });

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,8 +1,11 @@
 import assert from 'assert';
+import { version } from 'graphql';
 import { run } from '../src/runner.js';
 import { createReadStream } from 'fs';
 import { Readable } from 'stream';
 import { stripAnsi } from './strip_ansi.js';
+
+const itPotentially = version.startsWith('15.') ? it : it.skip;
 
 describe('Runner', () => {
   var stdout;
@@ -115,45 +118,51 @@ describe('Runner', () => {
       assert.equal(0, exitCode);
     });
 
-    it('allows setting descriptions using comments in GraphQL SDL', async () => {
-      const argv = [
-        'node',
-        'lib/cli.js',
-        '--format',
-        'text',
-        '--comment-descriptions',
-        '--rules',
-        'fields-have-descriptions',
-        `${__dirname}/fixtures/schema.comment-descriptions.graphql`,
-      ];
+    itPotentially(
+      'allows setting descriptions using comments in GraphQL SDL',
+      async () => {
+        const argv = [
+          'node',
+          'lib/cli.js',
+          '--format',
+          'text',
+          '--comment-descriptions',
+          '--rules',
+          'fields-have-descriptions',
+          `${__dirname}/fixtures/schema.comment-descriptions.graphql`,
+        ];
 
-      await run(mockStdout, mockStdin, mockStderr, argv);
+        await run(mockStdout, mockStdin, mockStderr, argv);
 
-      const expected =
-        `${__dirname}/fixtures/schema.comment-descriptions.graphql\n` +
-        '3:3 The field `Query.a` is missing a description.  fields-have-descriptions\n' +
-        '\n' +
-        '✖ 1 error detected\n';
+        const expected =
+          `${__dirname}/fixtures/schema.comment-descriptions.graphql\n` +
+          '3:3 The field `Query.a` is missing a description.  fields-have-descriptions\n' +
+          '\n' +
+          '✖ 1 error detected\n';
 
-      assert.equal(expected, stripAnsi(stdout));
-    });
+        assert.equal(expected, stripAnsi(stdout));
+      }
+    );
 
-    it('allows using old `implements` syntax in GraphQL SDL', async () => {
-      const argv = [
-        'node',
-        'lib/cli.js',
-        '--format',
-        'json',
-        '--old-implements-syntax',
-        '--rules',
-        'types-have-descriptions',
-        `${__dirname}/fixtures/schema.old-implements.graphql`,
-      ];
+    itPotentially(
+      'allows using old `implements` syntax in GraphQL SDL',
+      async () => {
+        const argv = [
+          'node',
+          'lib/cli.js',
+          '--format',
+          'json',
+          '--old-implements-syntax',
+          '--rules',
+          'types-have-descriptions',
+          `${__dirname}/fixtures/schema.old-implements.graphql`,
+        ];
 
-      await run(mockStdout, mockStdin, mockStderr, argv);
+        await run(mockStdout, mockStdin, mockStderr, argv);
 
-      assert.deepEqual([], JSON.parse(stdout)['errors']);
-    });
+        assert.deepEqual([], JSON.parse(stdout)['errors']);
+      }
+    );
 
     it('validates using new `implements` syntax in GraphQL SDL', async () => {
       const argv = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,7 +1734,7 @@ graceful-fs@^4.1.11:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
 
-graphql@^15.0.0:
+graphql@=15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.0.0.tgz#042a5eb5e2506a2e2111ce41eb446a8e570b8be9"
   integrity sha512-ZyVO1xIF9F+4cxfkdhOJINM+51B06Friuv4M66W7HzUOeFd+vNzUn4vtswYINPi6sysjf1M2Ri/rwZALqgwbaQ==


### PR DESCRIPTION
Add support for `graphql` v16 while continuing to support `graphql` v15. The diff is best viewed with whitespace hidden, for example:

- https://github.com/cjoudrey/graphql-schema-linter/pull/298/files?diff=split&w=1