### PR TITLE
Move integration tests so that they are tested against each GraphQL version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ before_script:
   - yarn prepare
 script:
   - yarn test:ci
-  - node lib/cli.js --version
-  - node lib/cli.js test/fixtures/valid.graphql
-  - cat test/fixtures/valid.graphql | node lib/cli.js --stdin
   - yarn prettier --check src/**/*.js
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha test/index.js && yarn test:integration",
-    "test:integration": "node lib/cli.js --version && node lib/cli.js test/fixtures/valid.graphql && (cat test/fixtures/valid.graphql | node lib/cli.js --stdin)",
+    "test:integration": "node -e 'console.log(\"GraphQL version: \", require(\"graphql\").version);' node lib/cli.js --version && node lib/cli.js test/fixtures/valid.graphql && (cat test/fixtures/valid.graphql | node lib/cli.js --stdin)",
     "test:ci": "yarn test && yarn test:ci:graphql-v15.x && yarn test:ci:graphql-v16.x",
     "test:ci:graphql-v15.x": "yarn upgrade graphql@^15.0.0 && yarn test",
     "test:ci:graphql-v16.x": "yarn upgrade graphql@^16.0.0 && yarn test",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Christian Joudrey",
   "main": "lib/index.js",
   "scripts": {
-    "test": "mocha test/index.js",
+    "test": "mocha test/index.js && yarn test:integration",
+    "test:integration": "node lib/cli.js --version && node lib/cli.js test/fixtures/valid.graphql && (cat test/fixtures/valid.graphql | node lib/cli.js --stdin)",
     "test:ci": "yarn test && yarn test:ci:graphql-v15.x && yarn test:ci:graphql-v16.x",
     "test:ci:graphql-v15.x": "yarn upgrade graphql@^15.0.0 && yarn test",
     "test:ci:graphql-v16.x": "yarn upgrade graphql@^16.0.0 && yarn test",


### PR DESCRIPTION
Despite having good test coverage, a while ago I accidentally published a version of `graphql-schema-linter` that contained a bug that was only seen when running the CLI. I ended up introducing a few integration tests as an extra sanity check.

This PR moves those tests such that they get run for each supported GraphQL version.