### PR TITLE
Correctly detect unused object types when using custom schema roots

### DIFF
--- a/src/rules/defined_types_are_used.js
+++ b/src/rules/defined_types_are_used.js
@@ -1,17 +1,30 @@
 import { ValidationError } from '../validation_error';
 
 export function DefinedTypesAreUsed(context) {
-  var ignoredTypes = ['Query', 'Mutation', 'Subscription'];
+  var defaultRootNames = {
+    Query: 'query',
+    Mutation: 'mutation',
+    Subscription: 'subscription',
+  };
   var definedTypes = [];
   var referencedTypes = new Set();
+  var specifiedRoots = new Set();
 
   var recordDefinedType = (node) => {
-    if (ignoredTypes.indexOf(node.name.value) == -1) {
-      definedTypes.push(node);
-    }
+    definedTypes.push(node);
   };
 
   return {
+    SchemaDefinition: (node) => {
+      node.operationTypes.forEach((operationType) =>
+        specifiedRoots.add(operationType.operation)
+      );
+    },
+    SchemaExtension: (node) => {
+      node.operationTypes.forEach((operationType) =>
+        specifiedRoots.add(operationType.operation)
+      );
+    },
     ScalarTypeDefinition: recordDefinedType,
     ObjectTypeDefinition: recordDefinedType,
     InterfaceTypeDefinition: recordDefinedType,
@@ -19,13 +32,27 @@ export function DefinedTypesAreUsed(context) {
     EnumTypeDefinition: recordDefinedType,
     InputObjectTypeDefinition: recordDefinedType,
 
-    NamedType: (node, key, parent, path, ancestors) => {
+    NamedType: (node) => {
       referencedTypes.add(node.name.value);
     },
 
     Document: {
       leave: (node) => {
         definedTypes.forEach((node) => {
+          // If a schema root operation type is undefined, we can assume the object type that is named after the operation type is used (https://spec.graphql.org/draft/#sec-Root-Operation-Types.Default-Root-Operation-Type-Names)
+          //
+          // For example, if no mutation root is specified, we treat the Mutation object type (if any) as referenced.
+
+          let isDefaultRootName =
+            Object.keys(defaultRootNames).indexOf(node.name.value) > -1;
+
+          if (
+            isDefaultRootName &&
+            !specifiedRoots.has(defaultRootNames[node.name.value])
+          ) {
+            referencedTypes.add(node.name.value);
+          }
+
           if (node.kind == 'ObjectTypeDefinition') {
             let implementedInterfaces = node.interfaces.map((node) => {
               return node.name.value;

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -18,13 +18,15 @@ export function expectFailsRule(
   rule,
   schemaSDL,
   expectedErrors = [],
-  configurationOptions = {}
+  configurationOptions = {},
+  omitDefaultSchema = false
 ) {
   return expectFailsRuleWithConfiguration(
     rule,
-    schemaSDL,
+    `${schemaSDL}`,
     configurationOptions,
-    expectedErrors
+    expectedErrors,
+    omitDefaultSchema
   );
 }
 
@@ -32,9 +34,12 @@ export function expectFailsRuleWithConfiguration(
   rule,
   schemaSDL,
   configurationOptions,
-  expectedErrors = []
+  expectedErrors = [],
+  omitDefaultSchema = false
 ) {
-  const errors = validateSchemaWithRule(rule, schemaSDL, configurationOptions);
+  var schema = omitDefaultSchema ? schemaSDL : `${schemaSDL}${DefaultSchema}`;
+
+  const errors = validateSchemaWithRule(rule, schema, configurationOptions);
 
   assert(errors.length > 0, "Expected rule to fail but didn't");
 
@@ -52,7 +57,7 @@ export function expectFailsRuleWithConfiguration(
 }
 
 export function expectPassesRule(rule, schemaSDL, configurationOptions = {}) {
-  expectPassesRuleWithConfiguration(rule, schemaSDL, configurationOptions);
+  expectPassesRuleWithConfiguration(rule, `${schemaSDL}`, configurationOptions);
 }
 
 export function expectPassesRuleWithConfiguration(
@@ -60,7 +65,11 @@ export function expectPassesRuleWithConfiguration(
   schemaSDL,
   configurationOptions
 ) {
-  const errors = validateSchemaWithRule(rule, schemaSDL, configurationOptions);
+  const errors = validateSchemaWithRule(
+    rule,
+    `${schemaSDL}${DefaultSchema}`,
+    configurationOptions
+  );
 
   assert(
     errors.length == 0,
@@ -70,7 +79,7 @@ export function expectPassesRuleWithConfiguration(
 
 function validateSchemaWithRule(rule, schemaSDL, configurationOptions) {
   const rules = [rule];
-  const schema = new Schema(`${schemaSDL}${DefaultSchema}`, null);
+  const schema = new Schema(schemaSDL, null);
   const configuration = new Configuration(schema, configurationOptions);
   const errors = validateSchemaDefinition(schema, rules, configuration);
   const transformedErrors = errors.map((error) => ({

--- a/test/rules/defined_types_are_used.js
+++ b/test/rules/defined_types_are_used.js
@@ -179,7 +179,7 @@ describe('DefinedTypesAreUsed rule', () => {
     );
   });
 
-  it('ignores unreferenced Mutation object type', () => {
+  it('ignores unreferenced Mutation object type when schema definition is omitted', () => {
     expectPassesRule(
       DefinedTypesAreUsed,
       `
@@ -190,7 +190,7 @@ describe('DefinedTypesAreUsed rule', () => {
     );
   });
 
-  it('ignores unreferenced Subscription object type', () => {
+  it('ignores unreferenced Subscription object type when schema definition is omitted', () => {
     expectPassesRule(
       DefinedTypesAreUsed,
       `
@@ -201,14 +201,165 @@ describe('DefinedTypesAreUsed rule', () => {
     );
   });
 
-  it('ignores unreferenced Query object type', () => {
-    expectPassesRule(
+  it('reports unused Mutation object type when schema definition is provided', () => {
+    expectFailsRule(
       DefinedTypesAreUsed,
       `
-      extend type Query {
+      type Mutation {
         c: String
       }
-    `
+
+      type Something {
+        a: String
+      }
+
+      schema {
+        query: Query
+        mutation: Something
+      }
+    `,
+      [
+        {
+          message:
+            'The type `Mutation` is defined in the schema but not used anywhere.',
+          locations: [{ line: 2, column: 7 }],
+        },
+      ]
+    );
+  });
+
+  it('reports unused Subscription object type when schema definition is provided', () => {
+    expectFailsRule(
+      DefinedTypesAreUsed,
+      `
+      type Subscription {
+        c: String
+      }
+
+      type Something {
+        a: String
+      }
+
+      schema {
+        query: Query
+        subscription: Something
+      }
+    `,
+      [
+        {
+          message:
+            'The type `Subscription` is defined in the schema but not used anywhere.',
+          locations: [{ line: 2, column: 7 }],
+        },
+      ]
+    );
+  });
+
+  it('reports unused Query object type when schema definition is provided', () => {
+    expectFailsRule(
+      DefinedTypesAreUsed,
+      `
+      type Query {
+        c: String
+      }
+
+      type Something {
+        a: String
+      }
+
+      schema {
+        query: Something
+      }
+    `,
+      [
+        {
+          message:
+            'The type `Query` is defined in the schema but not used anywhere.',
+          locations: [{ line: 2, column: 7 }],
+        },
+      ],
+      {},
+      true
+    );
+  });
+
+  it('reports unused Query object type when schema has been extended', () => {
+    expectFailsRule(
+      DefinedTypesAreUsed,
+      `
+      type Query {
+        c: String
+      }
+
+      type Something {
+        a: String
+      }
+
+      extend schema {
+        query: Something
+      }
+    `,
+      [
+        {
+          message:
+            'The type `Query` is defined in the schema but not used anywhere.',
+          locations: [{ line: 2, column: 7 }],
+        },
+      ],
+      {},
+      true
+    );
+  });
+
+  it('reports unused Mutation object type when schema has been extended', () => {
+    expectFailsRule(
+      DefinedTypesAreUsed,
+      `
+      type Mutation {
+        a: String
+      }
+
+      type Something {
+        a: String
+      }
+
+      extend schema {
+        mutation: Something
+      }
+    `,
+      [
+        {
+          message:
+            'The type `Mutation` is defined in the schema but not used anywhere.',
+          locations: [{ line: 2, column: 7 }],
+        },
+      ]
+    );
+  });
+
+  it('reports unused Subscription object type when schema has been extended', () => {
+    expectFailsRule(
+      DefinedTypesAreUsed,
+      `
+      type Subscription {
+        a: String
+      }
+
+      type Something {
+        a: String
+      }
+
+      extend schema {
+        subscription: Something
+      }
+    `,
+      [
+        {
+          message:
+            'The type `Subscription` is defined in the schema but not used anywhere.',
+          locations: [{ line: 2, column: 7 }],
+        },
+      ]
     );
   });
 });


### PR DESCRIPTION
Inspired by prior work done in https://github.com/cjoudrey/graphql-schema-linter/pull/266.

This pull request modifies the `DefinedTypesAreUsed` rule to report unused types named `Query`, `Mutation`, and `Subscription` when the schema is configured to use different root object types.

For example, the following schema would report an error:

```graphql
# Query is unused and will be reported as so.
type Query {
  a: String
}

type QueryRoot {
  a: String
}

schema {
  query: QueryRoot
}
```